### PR TITLE
DESCW-912 Added template export options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
+## 1.1.2: February 14, 2023
+- Added the ability to export Block Theme templates, teplate parts and global styles via the WordPress exporter tool. ([DESCW-912]https://apps.itsm.gov.bc.ca/jira/browse/DESCW-912))
+
 ## 1.1.1: February 12, 2023
-- Restructured `src` and `inc/core` directories – to put more focus on the src directory. Moved away from functional structure to a class/loader system. Added an autoloader to the Setup and reworked the hooks system to utilise this approach through `src/Actions` and `src/Filters` class directories. Admin pages for options, notifications banner and documentation pages moved into `src/Templates`. ([DESCW-911]https://apps.itsm.gov.bc.ca/jira/browse/DESCW-901))
+- Restructured `src` and `inc/core` directories – to put more focus on the src directory. Moved away from functional structure to a class/loader system. Added an autoloader to the Setup and reworked the hooks system to utilise this approach through `src/Actions` and `src/Filters` class directories. Admin pages for options, notifications banner and documentation pages moved into `src/Templates`. ([DESCW-911]https://apps.itsm.gov.bc.ca/jira/browse/DESCW-911))
 
 ## 1.1.0: February 8, 2023
 - Adds a custom post type for "Custom Patterns" and register any categorised Custom Pattern post type as patterns within the pattern picker. ([DESCW-911]https://apps.itsm.gov.bc.ca/jira/browse/DESCW-911))

--- a/checklist.md
+++ b/checklist.md
@@ -1,10 +1,10 @@
-Created at 2023-02-12 3:00 pm
+Created at 2023-02-14 5:06 pm
 
 * [yes] Updated version in composer.json
 * [yes] Updated version in style.css or plugin file
 * [yes] Updated CHANGELOG.md to include jira ticket
 * [no] Updated README.md for new functionality
-* [yes] Built assets for production (npm run build:production)
+* [no] Built assets for production (npm run build:production)
 * [✓] Verified coding standards (phpcs)
 * [✓] Run PHP tests
 * [✓] Lint javascript

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "bcgov-theme/bcgov-wordpress-block-theme",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "type": "wordpress-theme",
     "repositories": [
         {

--- a/src/Actions/ExportOptions.php
+++ b/src/Actions/ExportOptions.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Bcgov\Theme\Block\Actions;
+
+/**
+ * Registers theme export options in admin.
+ *
+ * @since 1.1.2
+ *
+ * @package Bcgov/Theme/Block
+ */
+class ExportOptions {
+	/**
+	 * Register Custom Settings and populate with default values.
+	 *
+	 * @since 1.0.3
+	 *
+	 * @return void
+	 */
+	public function bcgov_block_theme_exports() {
+		if ( current_user_can( 'export' ) ) {
+			echo '<p><label><input type="radio" name="content" value="wp_template" /> Block Theme: Templates</label></p>';
+			echo '<p><label><input type="radio" name="content" value="wp_template_part" /> Block Theme: Template Parts</label></p>';
+			echo '<p><label><input type="radio" name="content" value="wp_global_styles" /> Block Theme: Global Styles</label></p>';
+		}
+	}
+}

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -31,6 +31,7 @@ class Setup {
 		$theme_dependencies             = new Actions\Dependencies();
 		$theme_register_custom_patterns = new Actions\RegisterCustomPatternsPostType();
 		$theme_enqueue_and_inject       = new Actions\EnqueueAndInject();
+		$theme_exports                  = new Actions\ExportOptions();
 		$theme_register_block_patterns  = new Actions\PatternsSetup();
 
 		// Filters.
@@ -44,6 +45,7 @@ class Setup {
         add_action( 'admin_init', [ $theme_admin_options, 'bcgov_block_theme_custom_settings' ] );
 		add_action( 'admin_menu', [ $theme_admin_menus, 'bcgov_block_theme_menu' ] );
 		add_action( 'admin_notices', [ $theme_dependencies, 'bcgov_block_theme_dependencies' ] );
+		add_action( 'export_filters', [ $theme_exports, 'bcgov_block_theme_exports' ] );
 		add_action( 'after_setup_theme', [ $theme_supports, 'bcgov_block_theme' ] );
 		add_action( 'init', [ $theme_register_custom_patterns, 'bcgov_block_theme_register_custom_pattern' ] );
 		add_action( 'wp_enqueue_scripts', [ $theme_enqueue_and_inject, 'bcgov_block_theme_enqueue_scripts' ] );

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ Description: WordPress Block theme is a theme that leverages the full-site editi
 Requires at least: 5.9
 Tested up to: 6.0.1
 Requires PHP: 7.4
-Version: 1.1.1
+Version: 1.1.2
 License: Apache License Version 2.0
 License URI: LICENSE
 Text Domain: bcgov-blocks-theme


### PR DESCRIPTION
- Initial pass at Import / Export theme templates and theme settings. 
- Exports Block Theme templates, template parts, and global styles via the WordPress exporter tool.
- Importing seems to work as intended, further testing on staging environment needed.