### PR TITLE
DESCW-1225 Default per-block font size in theme.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## 1.2.4 June 26, 2023
+## 1.2.4 June 28, 2023
 - Fixed horizontal scrolling due to uncorrected 100vw width. Added horizontal overflow supression for alignful conditions that cause side scrolling on some small desktop resolutions. ([DESCW-1226](https://apps.itsm.gov.bc.ca/jira/browse/DESCW-1226))
 - Fixed right aligned ribbon navigation sub menu placement offset. Added a check for language switcher synthesised menu in ribbon state. ([DESCW-1225](https://apps.itsm.gov.bc.ca/jira/browse/DESCW-1225))
+- Added default font size styling to paragraph, list-item and other text-related blocks through theme.json CSS.([DESCW-1231](https://apps.itsm.gov.bc.ca/jira/browse/DESCW-1231))
 
 
 ## 1.2.3 June 7, 2023

--- a/checklist.md
+++ b/checklist.md
@@ -1,4 +1,4 @@
-Created at 2023-06-26 6:16 pm
+Created at 2023-06-28 1:51 pm
 
 * [yes] Updated version in composer.json
 * [yes] Updated version in style.css or plugin file

--- a/style.css
+++ b/style.css
@@ -4,8 +4,8 @@ Theme URI: https://github.com/bcgov/bcgov-wordpress-block-theme
 Author: govwordpress@gov.bc.ca
 Author URI: https://apps.itsm.gov.bc.ca/jira/browse/DESCW-162
 Description: WordPress Block theme is a theme that leverages the full-site editing functionality that is being built in the Gutenberg plugin.
-Requires at least: 5.9
-Tested up to: 6.2
+Requires at least: 6.2
+Tested up to: 6.2.2
 Requires PHP: 7.4
 Version: 1.2.4
 License: Apache License Version 2.0

--- a/theme.json
+++ b/theme.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
 	"title": "BCGov Default",
 	"patterns": [
@@ -321,18 +322,15 @@
 		},
 		"spacing": {
 			"blockGap": null,
-			"spacing": {
-				"blockGap": null,
-				"customSpacingSize": true,
-				"spacingScale": {
-					"operator": "*",
-					"increment": 1.75,
-					"steps": 9,
-					"mediumStep": 1.5,
-					"unit": "rem"
-				}
+			"customSpacingSize": true,
+			"spacingScale": {
+				"operator": "*",
+				"increment": 1.75,
+				"steps": 9,
+				"mediumStep": 1.5,
+				"unit": "rem"
 			}
-		},		
+		},
 		"typography": {
 			"fluid": true,
 			"fontSizes": [
@@ -387,6 +385,26 @@
 		"custom": {}
 	},
 	"styles": {
+		"blocks": {
+			"core/list-item": {
+				"css": "& { font-size: clamp(var(--wp--preset--font-size--normal), 1rem + ((1vw - 0.48rem) * 0.481), 1.25rem); }"
+			},
+			"core/navigation": {
+				"css": "& li { font-size: var(--wp--preset--font-size--normal); }"
+			},
+			"core/paragraph": {
+				"css": "& { font-size: clamp(var(--wp--preset--font-size--normal), 1rem + ((1vw - 0.48rem) * 0.481), 1.25rem); }"
+			},
+			"core/pullquote": {
+				"css": "& { font-size: clamp(var(--wp--preset--font-size--normal), 1rem + ((1vw - 0.48rem) * 0.481), 1.25rem); }"
+			},
+			"core/quote": {
+				"css": "& { font-size: clamp(var(--wp--preset--font-size--normal), 1rem + ((1vw - 0.48rem) * 0.481), 1.25rem); }"
+			},
+			"core/site-title": {
+				"css": "& { font-size: clamp(var(--wp--preset--font-size--normal), 1rem + ((1vw - 0.48rem) * 0.481), 1.25rem); }"
+			}
+		},
 		"color": {
 			"background": "var(--wp--preset--color--background)",
 			"text": "var(--wp--preset--color--foreground)"


### PR DESCRIPTION
- Added default font size styling to paragraph, list-item and other text-related blocks through theme.json CSS
- Leans into WordPress --wp--preset--font-size--normal variable and only affects default state
- Uses WordPress 6.2 support for per-block CSS in theme.json – style.css required version updated accordingly