### PR TITLE
DESCW-1412 Custom Google Site Name injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.9 Aug 5, 2023
+- Added Google Site Name structured content injection and custom site name settings ([DESCW-1412](https://apps.itsm.gov.bc.ca/jira/browse/DESCW-1412))
+
 ## 1.2.8 July 28, 2023
 - Upgraded BC Sans font to 2.0 ([DESCW-1234](https://apps.itsm.gov.bc.ca/jira/browse/DESCW-1234))
 

--- a/checklist.md
+++ b/checklist.md
@@ -1,4 +1,4 @@
-Created at 2023-07-28 12:03 pm
+Created at 2023-08-05 11:28 am
 
 * [yes] Updated version in composer.json
 * [yes] Updated version in style.css or plugin file

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bcgov-wordpress-block-theme",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Bcgov WordPress Block Theme",
   "author": "govwordpress@gov.bc.ca",
   "license": "Apache-2.0",

--- a/src/Actions/BcgovSettings.php
+++ b/src/Actions/BcgovSettings.php
@@ -292,10 +292,13 @@ class BcgovSettings {
         if ( empty( $google_site_name ) ) {
             $google_site_name = $default_site_name;
         }
+
+        $domain = wp_parse_url( get_site_url() );
+
 		?>
         <input type="text" name="bcgov_google_site_name_settings" value="<?php echo esc_attr( $google_site_name ); ?>" placeholder="Enter your Google Site Name here" style="width: 320px" />
 
-        <p class="description">This value will be used in the JSON-LD script for the Google Site Name. Defaults to WordPress site settings but can be used for finer control of the Google Site Name required to differentiate the site from the inferred Gov.bc.ca site naming in Google organic search results.</p>
+        <p class="description" style="max-width: 120ch;">This value will be used to tell the Google Search index the preferred Site Name. The name default is the Site Title in the WordPress site settings but can be overridden here for finer control of the Google Site Name required to differentiate the site from the inferred Gov.bc.ca site naming in Google organic search results. Note this feature provides an Alternate Site Name of <strong><?php echo esc_html( $domain['host'] ); ?></strong> so it is not necessary to use the domain as the preferred Site&nbsp;Name.</p>
 		<?php
     }
 }

--- a/src/Actions/EnqueueAndInject.php
+++ b/src/Actions/EnqueueAndInject.php
@@ -147,12 +147,15 @@ class EnqueueAndInject {
 			$google_site_name = $default_site_name;
 		}
 
+		$domain = wp_parse_url( get_site_url() );
+
 		// Prepare the JSON data.
 		$json_data = array(
-			'@context' => 'https://schema.org',
-			'@type'    => 'WebSite',
-			'name'     => $google_site_name,
-			'url'      => home_url(),
+			'@context'      => 'https://schema.org',
+			'@type'         => 'WebSite',
+			'name'          => $google_site_name,
+			'alternateName' => [ $domain['host'] ],
+			'url'           => home_url(),
 		);
 
 		// Output the inline script.

--- a/src/Actions/EnqueueAndInject.php
+++ b/src/Actions/EnqueueAndInject.php
@@ -125,4 +125,38 @@ class EnqueueAndInject {
 
 		return $javascript_variables;
 	}
+
+	/**
+     * Generates and outputs the JSON-LD script for the Google Site Name.
+     *
+     * Retrieves the Google Site Name setting and generates the JSON-LD script in the format
+     * required by Google for better representation in organic search results.
+     *
+     * @since 1.2.9
+     * @return void
+     */
+	public function bcgov_block_theme_generate_google_ld_json() {
+		// Get the current Google Site Name setting.
+		$google_site_name = get_option( 'bcgov_google_site_name_settings', '' );
+
+		// Get the default Site Name from WordPress settings.
+		$default_site_name = get_bloginfo( 'name' );
+
+		// If the Google Site Name is not set, use the default Site Name as the default value.
+		if ( empty( $google_site_name ) ) {
+			$google_site_name = $default_site_name;
+		}
+
+		// Prepare the JSON data.
+		$json_data = array(
+			'@context' => 'https://schema.org',
+			'@type'    => 'WebSite',
+			'name'     => $google_site_name,
+			'url'      => home_url(),
+		);
+
+		// Output the inline script.
+		echo '<script type="application/ld+json">' . wp_json_encode( $json_data ) . '</script>';
+	}
+
 }

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -64,6 +64,7 @@ class Setup {
 		add_action( 'after_setup_theme', [ $theme_supports, 'bcgov_block_theme' ] );
 		add_action( 'init', [ $theme_register_custom_patterns, 'bcgov_block_theme_register_custom_pattern' ] );
 		add_action( 'wp_enqueue_scripts', [ $theme_enqueue_and_inject, 'bcgov_block_theme_enqueue_scripts' ] );
+		add_action( 'wp_head', [ $theme_enqueue_and_inject, 'bcgov_block_theme_generate_google_ld_json' ] );
 
 		add_action( 'init', [ $theme_register_block_patterns, 'bcgov_blocks_theme_register_block_patterns' ], 9 );
 

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ Description: WordPress Block theme is a theme that leverages the full-site editi
 Requires at least: 6.2
 Tested up to: 6.2.2
 Requires PHP: 7.4
-Version: 1.2.8
+Version: 1.2.9
 License: Apache License Version 2.0
 License URI: LICENSE
 Text Domain: bcgov-blocks-theme


### PR DESCRIPTION
- provides a Site Name to Google Search using the new method and structured data as outlined at: https://developers.google.com/search/docs/appearance/site-names
- allows for using the default site name set in WordPress or for a custom variation in order to avoid conflict with the site title which is displayed on most headers
- setting custom site name straightforward text update in BCGov Block Theme Settings admin
- addition of Google structure data for Site Names now inserted by default, regardless of user changes to custom settings