### PR TITLE
Fixed editor permissions to allow core/navigation updates

### DIFF
--- a/checklist.md
+++ b/checklist.md
@@ -1,4 +1,4 @@
-Created at 2023-09-10 12:02 pm
+Created at 2023-09-11 1:26 pm
 
 * [yes] Updated version in composer.json
 * [yes] Updated version in style.css or plugin file

--- a/src/Actions/MenuEditor.php
+++ b/src/Actions/MenuEditor.php
@@ -11,184 +11,217 @@ namespace Bcgov\Theme\Block\Actions;
  */
 class MenuEditor {
 
-	/**
-	 * Register Custom Menu Manager Post Type.
-	 *
-	 * @since 1.2.11
-	 *
-	 * @return void
-	 */
-	public function menu_manager_post_type() {
-		$labels = [
-			'name'               => _x( 'Menu Manager', 'post type general name' ),
-			'singular_name'      => _x( 'Menu Manager', 'post type singular name' ),
-			'add_new'            => _x( 'Add New', 'menu manager' ),
-			'add_new_item'       => __( 'Add New Menu Manager' ),
-			'edit_item'          => __( 'Edit Menu Manager' ),
-			'new_item'           => __( 'New Menu Manager' ),
-			'view_item'          => __( 'View Menu Manager' ),
-			'search_items'       => __( 'Search Menu Manager' ),
-			'not_found'          => __( 'No menu manager found' ),
-			'not_found_in_trash' => __( 'No menu manager found in the Trash' ),
-			'parent_item_colon'  => '',
-			'menu_name'          => 'Menu Manager',
-		];
 
-		$args = [
-			'labels'             => $labels,
-			'public'             => false,
-			'publicly_queryable' => false,
-			'show_in_nav_menus'  => true,
-			'show_in_rest'       => true,
-			'supports'           => [ 'title', 'editor', 'author', 'thumbnail', 'excerpt', 'comments' ],
-			'show_ui'            => true,
-			'query_var'          => true,
-			'rewrite'            => [ 'slug' => 'menu-manager-post' ],
-			'menu_position'      => 60,
-			'menu_icon'          => 'dashicons-menu',
-			'template'           => [
-				[
-					'core/navigation',
-				],
-			],
-			'capabilities'       => [
-				'create_posts' => 'do_not_allow',
-				'delete_posts' => 'do_not_allow',
-			],
-			'map_meta_cap'       => true,
-		];
+    /**
+     * Register Custom Menu Manager Post Type.
+     *
+     * @since 1.2.11
+     *
+     * @return void
+     */
+    public function menu_manager_post_type() {
+        $labels = [
+            'name'               => _x( 'Menu Manager', 'post type general name' ),
+            'singular_name'      => _x( 'Menu Manager', 'post type singular name' ),
+            'add_new'            => _x( 'Add New', 'menu manager' ),
+            'add_new_item'       => __( 'Add New Menu Manager' ),
+            'edit_item'          => __( 'Edit Menu Manager' ),
+            'new_item'           => __( 'New Menu Manager' ),
+            'view_item'          => __( 'View Menu Manager' ),
+            'search_items'       => __( 'Search Menu Manager' ),
+            'not_found'          => __( 'No menu manager found' ),
+            'not_found_in_trash' => __( 'No menu manager found in the Trash' ),
+            'parent_item_colon'  => '',
+            'menu_name'          => 'Menu Manager',
+        ];
 
-		register_post_type( 'menu_manager_post', $args );
+        $args = [
+            'labels'             => $labels,
+            'public'             => false,
+            'publicly_queryable' => false,
+            'show_in_nav_menus'  => true,
+            'show_in_rest'       => true,
+            'supports'           => [ 'title', 'editor', 'author', 'thumbnail', 'excerpt', 'comments' ],
+            'show_ui'            => true,
+            'query_var'          => true,
+            'rewrite'            => [ 'slug' => 'menu-manager-post' ],
+            'menu_position'      => 60,
+            'menu_icon'          => 'dashicons-menu',
+            'template'           => [
+                [
+                    'core/navigation',
+                ],
+            ],
+            'capabilities'       => [
+                'create_posts' => 'do_not_allow',
+                'delete_posts' => 'do_not_allow',
+            ],
+            'map_meta_cap'       => true,
+        ];
 
-	}
+        register_post_type( 'menu_manager_post', $args );
+    }
 
-	/**
-	 * Create inital Menu Manager post (and maintain an existing if trashed).
-	 *
-	 * @since 1.2.11
-	 *
-	 * @return void
-	 */
-	public function create_initial_menu_manager_post() {
-		$post_title = 'Manage Site Navigation';
+    /**
+     * Create inital Menu Manager post (and maintain an existing if trashed).
+     *
+     * @since 1.2.11
+     *
+     * @return void
+     */
+    public function create_initial_menu_manager_post() {
+        $post_title = 'Manage Site Navigation';
 
-		$post_args = [
-			'post_title'     => $post_title,
-			'post_status'    => 'publish',
-			'post_type'      => 'menu_manager_post',
-			'post_content'   => '<!-- wp:group {"style":{"spacing":{"padding":{"top":"1rem","right":"1rem","bottom":"1rem","left":"1rem"},"margin":{"bottom":"3rem"}}},"borderColor":"gray-40","backgroundColor":"background","layout":{"type":"default"}} -->
-		<div class="wp-block-group has-border-color has-gray-40-border-color has-background-background-color has-background" style="margin-bottom:3rem;padding-top:1rem;padding-right:1rem;padding-bottom:1rem;padding-left:1rem"><!-- wp:heading {"align":"wide","style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}},"typography":{"fontSize":"1.25rem"}}} -->
-		<h2 class="wp-block-heading alignwide" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0;font-size:1.25rem">Instructions:</h2>
-		<!-- /wp:heading -->
-		
-		<!-- wp:list {"ordered":true,"style":{"typography":{"fontSize":"1rem"}}} -->
-		<ol style="font-size:1rem"><!-- wp:list-item -->
-		<li>Click on the Navigation block below to begin editing.</li>
-		<!-- /wp:list-item -->
-		
-		<!-- wp:list-item -->
-		<li>Use the Block Inspector to choose the menu you wish to edit. You may choose from any of the available menus or create a new menu if appropriate.</li>
-		<!-- /wp:list-item -->
-		
-		<!-- wp:list-item -->
-		<li>Edit the menu and save your changes.</li>
-		<!-- /wp:list-item --></ol>
-		<!-- /wp:list --></div>
-		<!-- /wp:group --><!-- wp:core/navigation {"align":"wide"} /-->',
-			'posts_per_page' => 1,
-			'template'       => [
-				[ 'core/navigation' ],
-			],
-			'capabilities'   => [
-				'create_posts' => 'do_not_allow',
-				'delete_posts' => 'do_not_allow',
-			],
-		];
+        $post_args = [
+            'post_title'     => $post_title,
+            'post_status'    => 'publish',
+            'post_type'      => 'menu_manager_post',
+            'post_content'   => '<!-- wp:group {"style":{"spacing":{"padding":{"top":"1rem","right":"1rem","bottom":"1rem","left":"1rem"},"margin":{"bottom":"3rem"}}},"borderColor":"gray-40","backgroundColor":"background","layout":{"type":"default"}} -->
+        <div class="wp-block-group has-border-color has-gray-40-border-color has-background-background-color has-background" style="margin-bottom:3rem;padding-top:1rem;padding-right:1rem;padding-bottom:1rem;padding-left:1rem"><!-- wp:heading {"align":"wide","style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}},"typography":{"fontSize":"1.25rem"}}} -->
+        <h2 class="wp-block-heading alignwide" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0;font-size:1.25rem">Instructions:</h2>
+        <!-- /wp:heading -->
+        
+        <!-- wp:list {"ordered":true,"style":{"typography":{"fontSize":"1rem"}}} -->
+        <ol style="font-size:1rem"><!-- wp:list-item -->
+        <li>Click on the Navigation block below to begin editing.</li>
+        <!-- /wp:list-item -->
+        
+        <!-- wp:list-item -->
+        <li>Use the Block Inspector to choose the menu you wish to edit. You may choose from any of the available menus or create a new menu if appropriate.</li>
+        <!-- /wp:list-item -->
+        
+        <!-- wp:list-item -->
+        <li>Edit the menu and save your changes.</li>
+        <!-- /wp:list-item --></ol>
+        <!-- /wp:list --></div>
+        <!-- /wp:group --><!-- wp:core/navigation {"align":"wide"} /-->',
+            'posts_per_page' => 1,
+            'template'       => [
+                [ 'core/navigation' ],
+            ],
+            'capabilities'   => [
+                'create_posts' => 'do_not_allow',
+                'delete_posts' => 'do_not_allow',
+            ],
+        ];
 
-		// Check if the post doesn't already exist.
-		$existing_post = new \WP_Query(
+        // Check if the post doesn't already exist.
+        $existing_post = new \WP_Query(
             [
-				'post_type'      => 'menu_manager_post',
-				'post_title'     => $post_title,
-				'post_content'   => '<!-- wp:group {"style":{"spacing":{"padding":{"top":"1rem","right":"1rem","bottom":"1rem","left":"1rem"},"margin":{"bottom":"3rem"}}},"borderColor":"gray-40","backgroundColor":"background","layout":{"type":"default"}} -->
-		<div class="wp-block-group has-border-color has-gray-40-border-color has-background-background-color has-background" style="margin-bottom:3rem;padding-top:1rem;padding-right:1rem;padding-bottom:1rem;padding-left:1rem"><!-- wp:heading {"align":"wide","style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}},"typography":{"fontSize":"1.25rem"}}} -->
-		<h2 class="wp-block-heading alignwide" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0;font-size:1.25rem">Instructions:</h2>
-		<!-- /wp:heading -->
-		
-		<!-- wp:list {"ordered":true,"style":{"typography":{"fontSize":"1rem"}}} -->
-		<ol style="font-size:1rem"><!-- wp:list-item -->
-		<li>Click on the Navigation block below to begin editing.</li>
-		<!-- /wp:list-item -->
-		
-		<!-- wp:list-item -->
-		<li>Use the Block Inspector to choose the menu you wish to edit. You may choose from any of the available menus or create a new menu if appropriate.</li>
-		<!-- /wp:list-item -->
-		
-		<!-- wp:list-item -->
-		<li>Edit the menu and save your changes.</li>
-		<!-- /wp:list-item --></ol>
-		<!-- /wp:list --></div>
-		<!-- /wp:group --><!-- wp:core/navigation {"align":"wide"} /-->',
-				'posts_per_page' => 1,
-				'template'       => [
-					[ 'core/navigation' ],
-				],
-				'capabilities'   => [
-					'create_posts' => 'do_not_allow',
-					'delete_posts' => 'do_not_allow',
-				],
+                'post_type'      => 'menu_manager_post',
+                'post_title'     => $post_title,
+                'post_content'   => '<!-- wp:group {"style":{"spacing":{"padding":{"top":"1rem","right":"1rem","bottom":"1rem","left":"1rem"},"margin":{"bottom":"3rem"}}},"borderColor":"gray-40","backgroundColor":"background","layout":{"type":"default"}} -->
+        <div class="wp-block-group has-border-color has-gray-40-border-color has-background-background-color has-background" style="margin-bottom:3rem;padding-top:1rem;padding-right:1rem;padding-bottom:1rem;padding-left:1rem"><!-- wp:heading {"align":"wide","style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}},"typography":{"fontSize":"1.25rem"}}} -->
+        <h2 class="wp-block-heading alignwide" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0;font-size:1.25rem">Instructions:</h2>
+        <!-- /wp:heading -->
+        
+        <!-- wp:list {"ordered":true,"style":{"typography":{"fontSize":"1rem"}}} -->
+        <ol style="font-size:1rem"><!-- wp:list-item -->
+        <li>Click on the Navigation block below to begin editing.</li>
+        <!-- /wp:list-item -->
+        
+        <!-- wp:list-item -->
+        <li>Use the Block Inspector to choose the menu you wish to edit. You may choose from any of the available menus or create a new menu if appropriate.</li>
+        <!-- /wp:list-item -->
+        
+        <!-- wp:list-item -->
+        <li>Edit the menu and save your changes.</li>
+        <!-- /wp:list-item --></ol>
+        <!-- /wp:list --></div>
+        <!-- /wp:group --><!-- wp:core/navigation {"align":"wide"} /-->',
+                'posts_per_page' => 1,
+                'template'       => [
+                    [ 'core/navigation' ],
+                ],
+                'capabilities'   => [
+                    'create_posts' => 'do_not_allow',
+                    'delete_posts' => 'do_not_allow',
+                ],
             ]
-		);
-
-		if ( ! $existing_post->have_posts() ) {
-			wp_insert_post( $post_args );
-		}
-
-		$this->remove_unused_menu_manager_post_type();
-
-		register_activation_hook( __FILE__, [ $this, 'create_initial_menu_manager_post' ] );
-	}
-
-	/**
-	 * Removes drafts and empties the trash for the 'menu_manager_post' post type.
-	 *
-	 * This function retrieves all trashed posts of the specified post type ('menu_manager_post')
-	 * and permanently deletes them from the database.
-	 *
-	 * @since 1.2.11
-	 *
-	 * @return void
-	 */
-	public function remove_unused_menu_manager_post_type() {
-
-		$post_type = 'menu_manager_post';
-
-		$trashed_posts = get_posts(
-            [
-				'post_type'      => $post_type,
-				'post_status'    => 'trash',
-				'posts_per_page' => -1,
-			]
         );
 
-		$draft_posts = get_posts(
+        if ( ! $existing_post->have_posts() ) {
+            wp_insert_post( $post_args );
+        }
+
+        $this->remove_unused_menu_manager_post_type();
+
+        register_activation_hook( __FILE__, [ $this, 'create_initial_menu_manager_post' ] );
+    }
+
+    /**
+     * Removes drafts and empties the trash for the 'menu_manager_post' post type.
+     *
+     * This function retrieves all trashed posts of the specified post type ('menu_manager_post')
+     * and permanently deletes them from the database.
+     *
+     * @since 1.2.11
+     *
+     * @return void
+     */
+    public function remove_unused_menu_manager_post_type() {
+        $post_type = 'menu_manager_post';
+
+        $trashed_posts = get_posts(
             [
-				'post_type'      => $post_type,
-				'post_status'    => 'draft',
-				'posts_per_page' => -1,
-			]
+                'post_type'      => $post_type,
+                'post_status'    => 'trash',
+                'posts_per_page' => -1,
+            ]
         );
 
-		if ( $trashed_posts ) {
-			foreach ( $trashed_posts as $post ) {
-				wp_delete_post( $post->ID, true );
-			}
-		}
+        $draft_posts = get_posts(
+            [
+                'post_type'      => $post_type,
+                'post_status'    => 'draft',
+                'posts_per_page' => -1,
+            ]
+        );
 
-		if ( $draft_posts ) {
-			foreach ( $draft_posts as $post ) {
-				wp_delete_post( $post->ID, true );
-			}
-		}
-	}
+        if ( $trashed_posts ) {
+            foreach ( $trashed_posts as $post ) {
+                wp_delete_post( $post->ID, true );
+            }
+        }
+
+        if ( $draft_posts ) {
+            foreach ( $draft_posts as $post ) {
+                wp_delete_post( $post->ID, true );
+            }
+        }
+    }
+
+    /**
+     * Allow the Editor role to manage navigation menus outside of the Full Site Editor.
+     *
+     * @since 1.2.11
+     */
+    public function add_editor_menu_capabilities() {
+        
+        if ( current_user_can( 'editor' ) ) {
+            $editor_role = get_role( 'editor' );
+
+            $editor_role->add_cap( 'edit_theme_options' );
+            $editor_role->add_cap( 'edit_navigation_block' );
+            $editor_role->remove_cap( 'edit_nav_menus' );
+            $editor_role->remove_cap( 'manage_sites' );
+            $editor_role->remove_cap( 'edit_themes' );
+            $editor_role->remove_cap( 'manage_options' );
+            $editor_role->remove_cap( 'switch_themes' );
+
+        }
+    }
+
+    /**
+     * Remove Appearance and Tools admin menu items for Editor roles.
+     *
+     * @since 1.2.11
+     */
+    public function hide_appearance_menu_for_editor() {
+        if ( current_user_can( 'editor' ) ) {
+            remove_menu_page( 'themes.php' );
+            remove_menu_page( 'tools.php' );
+        }
+    }
+
 }

--- a/src/Actions/MenuEditor.php
+++ b/src/Actions/MenuEditor.php
@@ -197,7 +197,7 @@ class MenuEditor {
      * @since 1.2.11
      */
     public function add_editor_menu_capabilities() {
-        
+
         if ( current_user_can( 'editor' ) ) {
             $editor_role = get_role( 'editor' );
 

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -5,9 +5,9 @@ namespace Bcgov\Theme\Block;
 use Bcgov\Theme\Block\Actions\{
     ThemeSupports,
     AdminMenus,
-	MenuEditor,
+    MenuEditor,
     AdminOptions,
-	BcgovSettings,
+    BcgovSettings,
     Dependencies,
     RegisterCustomPatternsPostType,
     EnqueueAndInject,
@@ -37,55 +37,55 @@ class Setup {
      */
     public function __construct() {
 
-		// Actions.
-		$theme_supports                 = new ThemeSupports();
-		$theme_admin_menus              = new AdminMenus();
-		$theme_menu_editor              = new MenuEditor();
-		$theme_admin_options            = new AdminOptions();
-		$theme_bcgov_settings           = new BcgovSettings();
-		$theme_dependencies             = new Dependencies();
-		$theme_register_custom_patterns = new RegisterCustomPatternsPostType();
-		$theme_enqueue_and_inject       = new EnqueueAndInject();
-		$theme_exports                  = new ExportOptions();
-		$theme_register_block_patterns  = new PatternsSetup();
-		$theme_page_custom_class        = new PageCustomClass();
+        // Actions.
+        $theme_supports                 = new ThemeSupports();
+        $theme_admin_menus              = new AdminMenus();
+        $theme_menu_editor              = new MenuEditor();
+        $theme_admin_options            = new AdminOptions();
+        $theme_bcgov_settings           = new BcgovSettings();
+        $theme_dependencies             = new Dependencies();
+        $theme_register_custom_patterns = new RegisterCustomPatternsPostType();
+        $theme_enqueue_and_inject       = new EnqueueAndInject();
+        $theme_exports                  = new ExportOptions();
+        $theme_register_block_patterns  = new PatternsSetup();
+        $theme_page_custom_class        = new PageCustomClass();
 
-		// Filters.
-		$filter_button_enhanced    = new ButtonEnhanced();
-		$filter_image_enhanced     = new ImageEnhanced();
-		$filter_mediatext_enhanced = new MediaTextEnhanced();
-		$filter_sitelogo_enhanced  = new SiteLogoEnhanced();
+        // Filters.
+        $filter_button_enhanced    = new ButtonEnhanced();
+        $filter_image_enhanced     = new ImageEnhanced();
+        $filter_mediatext_enhanced = new MediaTextEnhanced();
+        $filter_sitelogo_enhanced  = new SiteLogoEnhanced();
 
-		add_action( 'acf/init', [ $theme_admin_options, 'bcgov_block_theme_acf_init_block_types' ] );
-		add_action( 'admin_enqueue_scripts', [ $theme_enqueue_and_inject, 'bcgov_block_theme_enqueue_admin_scripts' ] );
+        add_action( 'acf/init', [ $theme_admin_options, 'bcgov_block_theme_acf_init_block_types' ] );
+        add_action( 'admin_enqueue_scripts', [ $theme_enqueue_and_inject, 'bcgov_block_theme_enqueue_admin_scripts' ] );
+        add_action( 'add_meta_boxes', [ $theme_page_custom_class, 'custom_page_meta_boxes' ], 10, 2 );
         add_action( 'admin_init', [ $theme_admin_options, 'bcgov_block_theme_custom_settings' ] );
-		add_action( 'admin_notices', [ $theme_dependencies, 'bcgov_block_theme_dependencies' ] );
-		add_action( 'admin_menu', [ $theme_admin_menus, 'bcgov_block_theme_menu' ] );
-		add_action( 'admin_menu', [ $theme_bcgov_settings, 'bcgov_add_settings_menu' ] );
-		add_action( 'export_filters', [ $theme_exports, 'bcgov_block_theme_exports' ] );
-		add_action( 'after_setup_theme', [ $theme_supports, 'bcgov_block_theme' ] );
-		add_action( 'init', [ $theme_register_custom_patterns, 'bcgov_block_theme_register_custom_pattern' ] );
-		add_action( 'wp_enqueue_scripts', [ $theme_enqueue_and_inject, 'bcgov_block_theme_enqueue_scripts' ] );
-		add_action( 'wp_head', [ $theme_enqueue_and_inject, 'bcgov_block_theme_generate_google_ld_json' ] );
+        add_action( 'admin_notices', [ $theme_dependencies, 'bcgov_block_theme_dependencies' ] );
+        add_action( 'admin_menu', [ $theme_admin_menus, 'bcgov_block_theme_menu' ] );
+        add_action( 'admin_menu', [ $theme_bcgov_settings, 'bcgov_add_settings_menu' ] );
+        add_action( 'admin_menu', [ $theme_menu_editor, 'hide_appearance_menu_for_editor' ] );
+        add_action( 'after_setup_theme', [ $theme_supports, 'bcgov_block_theme' ] );
+        add_action( 'export_filters', [ $theme_exports, 'bcgov_block_theme_exports' ] );
+        add_action( 'init', [ $theme_register_custom_patterns, 'bcgov_block_theme_register_custom_pattern' ] );
+        add_action( 'init', [ $theme_register_block_patterns, 'bcgov_blocks_theme_register_block_patterns' ], 9 );
+        add_action( 'init', [ $theme_menu_editor, 'add_editor_menu_capabilities' ] );
+        add_action( 'init', [ $theme_menu_editor, 'menu_manager_post_type' ], 9 );
+        add_action( 'init', [ $theme_menu_editor, 'create_initial_menu_manager_post' ] );
+        add_action( 'wp_enqueue_scripts', [ $theme_enqueue_and_inject, 'bcgov_block_theme_enqueue_scripts' ] );
+        add_action( 'wp_head', [ $theme_enqueue_and_inject, 'bcgov_block_theme_generate_google_ld_json' ] );
+        add_action( 'wp_trash_post', [ $theme_menu_editor, 'remove_unused_menu_manager_post_type' ] );
+        add_action( 'save_post', [ $theme_page_custom_class, 'custom_save_page_meta' ] );
 
-		add_action( 'init', [ $theme_register_block_patterns, 'bcgov_blocks_theme_register_block_patterns' ], 9 );
-		add_action( 'init', [ $theme_menu_editor, 'menu_manager_post_type' ], 9 );
-		add_action( 'init', [ $theme_menu_editor, 'create_initial_menu_manager_post' ] );
-		add_action( 'wp_trash_post', [ $theme_menu_editor, 'remove_unused_menu_manager_post_type' ] );
+        add_filter( 'body_class', [ $theme_page_custom_class, 'add_custom_class_to_body' ] );
 
-		// Custom Page Class combined Action & Filter hooks into Actions Class.
-		add_action( 'add_meta_boxes', [ $theme_page_custom_class, 'custom_page_meta_boxes' ], 10, 2 );
-		add_action( 'save_post', [ $theme_page_custom_class, 'custom_save_page_meta' ] );
-		add_filter( 'body_class', [ $theme_page_custom_class, 'add_custom_class_to_body' ] );
+        add_filter( 'get_custom_logo', [ $theme_supports, 'bcgov_block_theme_custom_logo' ] );
+        add_filter( 'wp_headers', [ $theme_admin_options, 'bcgov_block_theme_wp_headers' ] );
 
-		add_filter( 'get_custom_logo', [ $theme_supports, 'bcgov_block_theme_custom_logo' ] );
-		add_filter( 'wp_headers', [ $theme_admin_options, 'bcgov_block_theme_wp_headers' ] );
+        add_filter( 'render_block', [ $filter_button_enhanced, 'add_button_attributes' ], 10, 2 );
+        add_filter( 'render_block', [ $filter_image_enhanced, 'add_image_attributes' ], 10, 2 );
+        add_filter( 'render_block', [ $filter_mediatext_enhanced, 'add_media_text_attributes' ], 10, 2 );
+        add_filter( 'render_block', [ $filter_sitelogo_enhanced, 'add_site_logo_attributes' ], 10, 2 );
 
-		add_filter( 'render_block', [ $filter_button_enhanced, 'add_button_attributes' ], 10, 2 );
-		add_filter( 'render_block', [ $filter_image_enhanced, 'add_image_attributes' ], 10, 2 );
-		add_filter( 'render_block', [ $filter_mediatext_enhanced, 'add_media_text_attributes' ], 10, 2 );
-		add_filter( 'render_block', [ $filter_sitelogo_enhanced, 'add_site_logo_attributes' ], 10, 2 );
-
-		remove_theme_support( 'core-block-patterns' );
-	}
+        remove_theme_support( 'core-block-patterns' );
+    }
 }


### PR DESCRIPTION
- As predicted the Editor role was missing permissions to edit the Navigation block. This allows for that to happen by granting higher level permissions and then removing capabilities – See line 195+ of MenuEditor.php
- Also changes tabs for spaces, so looks a lot worse than it is.