### PR TITLE
Admin check for new menu capability exclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-## 1.2.11 Sept 10, 2023
+## 1.2.11 Sept 13, 2023
+- Updated admin menu check for Menu Manager feature. (Ticket unavailable)
 - Added a Navigation Menu Management feature so that Editors without access to the Full Site Editor are able to easily manage existing or new menus. Maintains a single post for this feature by cleaning up and removing draft or trashed posts. (Ticket unavailable)
 - Updated external link processing to use post-content class rather than ID to allow footer link handling. Removed overrides for fullwidth margins to work with updated WordPress core. ([DESCW-1478](https://apps.itsm.gov.bc.ca/jira/browse/DESCW-1478))
 

--- a/checklist.md
+++ b/checklist.md
@@ -1,4 +1,4 @@
-Created at 2023-09-11 1:26 pm
+Created at 2023-09-13 11:11 am
 
 * [yes] Updated version in composer.json
 * [yes] Updated version in style.css or plugin file

--- a/src/Actions/MenuEditor.php
+++ b/src/Actions/MenuEditor.php
@@ -198,7 +198,10 @@ class MenuEditor {
      */
     public function add_editor_menu_capabilities() {
 
-        if ( current_user_can( 'editor' ) ) {
+        $current_user = wp_get_current_user();
+
+        if ( current_user_can( 'editor' ) && ( ! $current_user->caps['administrator'] ) ) {
+
             $editor_role = get_role( 'editor' );
 
             $editor_role->add_cap( 'edit_theme_options' );
@@ -218,7 +221,10 @@ class MenuEditor {
      * @since 1.2.11
      */
     public function hide_appearance_menu_for_editor() {
-        if ( current_user_can( 'editor' ) ) {
+
+        $current_user = wp_get_current_user();
+
+        if ( current_user_can( 'editor' ) && ( ! $current_user->caps['administrator'] ) ) {
             remove_menu_page( 'themes.php' );
             remove_menu_page( 'tools.php' );
         }


### PR DESCRIPTION
- Editor capability check was also firing for Admins. Added a check to exclude that role.