### PR TITLE
Community contribution: Google Search Console verification option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.15 Oct 6, 2023
+- Added a Google Site Verification meta tag to the home page by way of the Block Theme options: eg: <meta name="google-site-verification" content="GOOGLE_PROVIDIED_CODE" /> (Community contribution)
+
 ## 1.2.14 Sept 29, 2023
 - Removed the required attribute from the button label input in the Custom Notice Banner Settings ([DESCW-1544](https://apps.itsm.gov.bc.ca/jira/browse/DESCW-1544))
 

--- a/checklist.md
+++ b/checklist.md
@@ -1,4 +1,4 @@
-Created at 2023-09-29 11:26 am
+Created at 2023-10-06 11:03 am
 
 * [yes] Updated version in composer.json
 * [yes] Updated version in style.css or plugin file

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "bcgov-theme/bcgov-wordpress-block-theme",
     "description": "Block Theme for BC Gov",
-    "version": "1.2.14",
+    "version": "1.2.15",
     "type": "wordpress-theme",
     "license": "Apache-2.0",
     "repositories": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "57698db830372b24368065aeeba26e7f",
+    "content-hash": "06313740010c3e615f5ae211d6fe244f",
     "packages": [],
     "packages-dev": [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bcgov-wordpress-block-theme",
-  "version": "1.2.13",
+  "version": "1.2.15",
   "description": "Bcgov WordPress Block Theme",
   "author": "govwordpress@gov.bc.ca",
   "license": "Apache-2.0",

--- a/src/Actions/BcgovSettings.php
+++ b/src/Actions/BcgovSettings.php
@@ -122,6 +122,13 @@ class BcgovSettings {
             [ $this, 'sanitize_bcgov_google_site_name_settings' ]
         );
 
+        // Add the Google Verify ownership setting.
+        register_setting(
+            'bcgov-settings-group',
+            'bcgov_google_verify_settings',
+            [ $this, 'sanitize_bcgov_google_verify_settings' ]
+        );
+
         // Add settings sections:
         // For BCGov Admin Notification settings.
         add_settings_section(
@@ -152,6 +159,14 @@ class BcgovSettings {
             'bcgov_google_site_name_settings',
             'Google Site Name',
             [ $this, 'bcgov_google_site_name_settings' ],
+            'bcgov-theme-settings'
+        );
+
+        // For Google Site Name setting.
+        add_settings_section(
+            'bcgov_google_verify_settings',
+            'Google Verification Code',
+            [ $this, 'bcgov_google_verify_settings' ],
             'bcgov-theme-settings'
         );
     }
@@ -205,7 +220,18 @@ class BcgovSettings {
         return $google_site_name;
     }
 
+    /**
+     * Sanitize and save the Google Verify text value.
+     *
+     * @param array $input The settings input.
+     * @return array The sanitized input.
+     */
+    public function sanitize_bcgov_google_verify_settings( $input ) {
+        // Sanitize the text field value.
+        $google_verify = sanitize_text_field( $input );
 
+        return $google_verify;
+    }
 
 
     /**
@@ -301,4 +327,34 @@ class BcgovSettings {
         <p class="description" style="max-width: 120ch;">This value will be used to tell the Google Search index the preferred Site Name. The name default is the Site Title in the WordPress site settings but can be overridden here for finer control of the Google Site Name required to differentiate the site from the inferred Gov.bc.ca site naming in Google organic search results. Note this feature provides an Alternate Site Name of <strong><?php echo esc_html( $domain['host'] ); ?></strong> so it is not necessary to use the domain as the preferred Site&nbsp;Name.</p>
 		<?php
     }
+
+    /**
+     * Sets the Google Search Console verification code.
+     *
+     * @since 1.2.15
+     * @return void
+     */
+    public function bcgov_google_verify_settings() {
+        $google_verify = ''; // Initialize the variable to an empty string.
+
+        if ( isset( $_POST['bcgov_google_verify_nonce'] ) && wp_verify_nonce( $_POST['bcgov_google_verify_nonce'], 'bcgov_google_verify_nonce' ) ) {
+            if ( isset( $_POST['bcgov_google_verify'] ) ) {
+                $google_verify = sanitize_text_field( $_POST['bcgov_google_verify'] );
+                update_option( 'bcgov_google_verify_settings', $google_verify );
+            }
+        }
+
+        // Get the current Google Site Name setting.
+        $google_verify = get_option( 'bcgov_google_verify_settings', $google_verify ); // Retrieve the saved value or use the default value.
+
+        ?>
+        <input type="text" name="bcgov_google_verify_settings" value="<?php echo esc_attr( $google_verify ); ?>" placeholder="Enter your Google Verification Code here" style="width: 320px" />
+
+        <p class="description" style="max-width: 120ch;">This value will be used to add a meta tag to your site's homepage, which is needed to verify ownership of the domain with Google. To get this code, you will need to go to the Welcome to <a target="external" href="https://search.google.com/search-console/welcome">Google Search Console page</a> and use the URL prefix tool. Once in the URL prefix tool, open the <strong>HTML tag</strong> option and copy the meta tag code provided. You must extract just the value of the "content" attribute and paste it into the field above. Once you have done that, press Save Changes below, and then go back to Google Search Console and click the <strong>Verify</strong> button.</p>
+        <p class="description" style="max-width: 120ch;">For example, if the HTML tag is:</p>
+        <p class="description" style="max-width: 120ch;">&lt;meta name="google-site-verification" content="<strong>XKEhZ_JE714ViwiTJ_Ok1-IaaCm52CG-6vWmW2g3fpE</strong>" /&gt;</p>
+        <p class="description" style="max-width: 120ch;">...you will only copy/paste the bolded portion of the string (without the surrounding quotes).</p>
+        <?php
+    }
+
 }

--- a/src/Actions/EnqueueAndInject.php
+++ b/src/Actions/EnqueueAndInject.php
@@ -162,4 +162,22 @@ class EnqueueAndInject {
 		echo '<script type="application/ld+json">' . wp_json_encode( $json_data ) . '</script>';
 	}
 
+	/**
+     * Generates and outputs the meta verification tag for Google Search Console.
+     *
+     * Required by Google for better representation in organic search results.
+     *
+     * @since 1.2.15
+     * @return void
+     */
+	public function bcgov_block_theme_generate_google_search_meta_tag() {
+		// Get the current Google Verification code setting.
+		$google_verify = get_option( 'bcgov_google_verify_settings', '' );
+
+		if ( ! empty( $google_verify ) ) {
+			// Output the meta tag if a verified code is available.
+			echo '<meta name="google-site-verification" content="' . esc_attr( $google_verify ) . '" />';
+		}
+	}
+
 }

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -72,6 +72,7 @@ class Setup {
         add_action( 'init', [ $theme_menu_editor, 'menu_manager_post_type' ], 9 );
         add_action( 'init', [ $theme_menu_editor, 'create_initial_menu_manager_post' ] );
         add_action( 'wp_enqueue_scripts', [ $theme_enqueue_and_inject, 'bcgov_block_theme_enqueue_scripts' ] );
+        add_action( 'wp_head', [ $theme_enqueue_and_inject, 'bcgov_block_theme_generate_google_search_meta_tag' ] );
         add_action( 'wp_head', [ $theme_enqueue_and_inject, 'bcgov_block_theme_generate_google_ld_json' ] );
         add_action( 'wp_trash_post', [ $theme_menu_editor, 'remove_unused_menu_manager_post_type' ] );
         add_action( 'save_post', [ $theme_page_custom_class, 'custom_save_page_meta' ] );

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ Description: WordPress Block theme is a theme that leverages the full-site editi
 Requires at least: 6.2
 Tested up to: 6.2.2
 Requires PHP: 7.4
-Version: 1.2.14
+Version: 1.2.15
 License: Apache License Version 2.0
 License URI: LICENSE
 Text Domain: bcgov-blocks-theme


### PR DESCRIPTION
- Adds a Google Site Verification meta tag to the home page by way of the Block Theme options: 
- eg: &lt;meta name="google-site-verification" content="GOOGLE_PROVIDIED_CODE" /&gt;
- As can be seen on https://search.google.com/search-console/welcome > URL prefix > HTML tag