### PR TITLE
fix documentation page redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.18 Dec 06, 2023
+- Fix documentation page redirect ([DESCW-1783](https://apps.itsm.gov.bc.ca/jira/browse/DESCW-1783))
+
 ## 1.2.17 Nov 30, 2023
 - Fix dependencies for vuepress builds
 - added template and admin documentation ([DESCW-1654](https://apps.itsm.gov.bc.ca/jira/browse/DESCW-1654))

--- a/checklist.md
+++ b/checklist.md
@@ -1,10 +1,10 @@
-Created at 2023-11-29 6:01 pm
+Created at 2023-12-06 10:50 am
 
 * [yes] Updated version in composer.json
 * [yes] Updated version in style.css or plugin file
 * [yes] Updated CHANGELOG.md to include jira ticket
 * [no] Updated README.md for new functionality
-* [yes] Built assets for production (npm run build:production)
+* [no] Built assets for production (npm run build:production)
 * [N/A] Updated the documentation (N/A, Updated, or a ticket ID)
 * [✓] Verified coding standards (phpcs)
 * [✓] Run PHP tests

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "bcgov-theme/bcgov-wordpress-block-theme",
     "description": "Block Theme for BC Gov",
-    "version": "1.2.17",
+    "version": "1.2.18",
     "type": "wordpress-theme",
     "license": "Apache-2.0",
     "repositories": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0f166972775bbac4dbedee0e59d29ea5",
+    "content-hash": "149215a175370e52360b26f2e56b9e3f",
     "packages": [],
     "packages-dev": [
         {
             "name": "antecedent/patchwork",
-            "version": "2.1.26",
+            "version": "2.1.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/antecedent/patchwork.git",
-                "reference": "f2dae0851b2eae4c51969af740fdd0356d7f8f55"
+                "reference": "16a1ab81559aabf14acb616141e801b32777f085"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/f2dae0851b2eae4c51969af740fdd0356d7f8f55",
-                "reference": "f2dae0851b2eae4c51969af740fdd0356d7f8f55",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/16a1ab81559aabf14acb616141e801b32777f085",
+                "reference": "16a1ab81559aabf14acb616141e801b32777f085",
                 "shasum": ""
             },
             "require": {
@@ -39,7 +39,7 @@
                 }
             ],
             "description": "Method redefinition (monkey-patching) functionality for PHP.",
-            "homepage": "http://patchwork2.org/",
+            "homepage": "https://antecedent.github.io/patchwork/",
             "keywords": [
                 "aop",
                 "aspect",
@@ -51,9 +51,9 @@
             ],
             "support": {
                 "issues": "https://github.com/antecedent/patchwork/issues",
-                "source": "https://github.com/antecedent/patchwork/tree/2.1.26"
+                "source": "https://github.com/antecedent/patchwork/tree/2.1.27"
             },
-            "time": "2023-09-18T08:18:37+00:00"
+            "time": "2023-12-03T18:46:49+00:00"
         },
         {
             "name": "bcgov/wordpress-scripts",
@@ -838,16 +838,16 @@
         },
         {
             "name": "phpcsstandards/phpcsextra",
-            "version": "1.1.2",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "746c3190ba8eb2f212087c947ba75f4f5b9a58d5"
+                "reference": "78b2cae1e9de1c05f0416de6f9a658cbb83ac324"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/746c3190ba8eb2f212087c947ba75f4f5b9a58d5",
-                "reference": "746c3190ba8eb2f212087c947ba75f4f5b9a58d5",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/78b2cae1e9de1c05f0416de6f9a658cbb83ac324",
+                "reference": "78b2cae1e9de1c05f0416de6f9a658cbb83ac324",
                 "shasum": ""
             },
             "require": {
@@ -895,9 +895,24 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
                 "source": "https://github.com/PHPCSStandards/PHPCSExtra"
             },
-            "time": "2023-09-20T22:06:18+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-12-02T14:30:12+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
@@ -1293,16 +1308,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.13",
+            "version": "9.6.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f3d767f7f9e191eab4189abe41ab37797e30b1be"
+                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f3d767f7f9e191eab4189abe41ab37797e30b1be",
-                "reference": "f3d767f7f9e191eab4189abe41ab37797e30b1be",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/05017b80304e0eb3f31d90194a563fd53a6021f1",
+                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1",
                 "shasum": ""
             },
             "require": {
@@ -1376,7 +1391,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.13"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.15"
             },
             "funding": [
                 {
@@ -1392,7 +1407,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-19T05:39:22+00:00"
+            "time": "2023-12-01T16:55:19+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/src/Filters/AllowedHosts.php
+++ b/src/Filters/AllowedHosts.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Handles theme filters for allowed redirect hosts.
+ *
+ * @since 1.1.1
+ *
+ * @package Bcgov/Theme/Block
+ */
+
+namespace Bcgov\Theme\Block\Filters;
+
+/**
+ * This class extends the list of allowed redirect hosts.
+ *
+ * @since 1.1.1
+ */
+class AllowedHosts {
+
+	/**
+	 * Extend allowed hosts by adding new sites to the list of safe redirect targets.
+	 *
+	 * @param  string[] $hosts Array of allowed host names.
+	 * @return string[]
+	 */
+	public function add_allowed_redirect_hosts( $hosts ) {
+        $my_hosts = array( 'bcgov.github.io' );
+        return array_merge( $hosts, $my_hosts );
+	}
+}

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -20,7 +20,8 @@ use Bcgov\Theme\Block\Filters\{
     ButtonEnhanced,
     ImageEnhanced,
     MediaTextEnhanced,
-    SiteLogoEnhanced
+    SiteLogoEnhanced,
+    AllowedHosts
 };
 
 
@@ -55,6 +56,7 @@ class Setup {
         $filter_image_enhanced     = new ImageEnhanced();
         $filter_mediatext_enhanced = new MediaTextEnhanced();
         $filter_sitelogo_enhanced  = new SiteLogoEnhanced();
+        $filter_redirect_hosts     = new AllowedHosts();
 
         add_action( 'acf/init', [ $theme_admin_options, 'bcgov_block_theme_acf_init_block_types' ] );
         add_action( 'admin_enqueue_scripts', [ $theme_enqueue_and_inject, 'bcgov_block_theme_enqueue_admin_scripts' ] );
@@ -85,6 +87,7 @@ class Setup {
         add_filter( 'render_block', [ $filter_image_enhanced, 'add_image_attributes' ], 10, 2 );
         add_filter( 'render_block', [ $filter_mediatext_enhanced, 'add_media_text_attributes' ], 10, 2 );
         add_filter( 'render_block', [ $filter_sitelogo_enhanced, 'add_site_logo_attributes' ], 10, 2 );
+        add_filter( 'allowed_redirect_hosts', [ $filter_redirect_hosts, 'add_allowed_redirect_hosts' ], 10, 2 );
 
         remove_theme_support( 'core-block-patterns' );
     }

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ Description: WordPress Block theme is a theme that leverages the full-site editi
 Requires at least: 6.2
 Tested up to: 6.2.2
 Requires PHP: 7.4
-Version: 1.2.17
+Version: 1.2.18
 License: Apache License Version 2.0
 License URI: LICENSE
 Text Domain: bcgov-blocks-theme


### PR DESCRIPTION
Fixes the redirect to https://bcgov.github.io/bcgov-wordpress-block-theme/ not working by adding bcgov.github.io to the allowed hosts list.