### PR TITLE
bugfix/descw1925: Updated Vuepress to 2.0.0-rc.0 to address XSS security concern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 1.4.1 Jan 26, 2024
+- Updated Vuepress to version 2.0.0-rc.0 in Documentation folder. ([DESCW-1925](https://apps.itsm.gov.bc.ca/jira/browse/DESCW-1925))
+
 ## 1.4.0 Jan 23, 2024
 - Added default styling for Gravity Forms that aligns with BC Government design system ([DESCW-1915](https://apps.itsm.gov.bc.ca/jira/browse/DESCW-1915))
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "bcgov-theme/bcgov-wordpress-block-theme",
     "description": "Block Theme for BC Gov",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "type": "wordpress-theme",
     "license": "Apache-2.0",
     "repositories": [

--- a/documentation/docs/.vuepress/config.js
+++ b/documentation/docs/.vuepress/config.js
@@ -1,6 +1,7 @@
 import { defaultTheme } from "@vuepress/theme-default";
 import { defineUserConfig } from "vuepress";
 import { searchPlugin } from "@vuepress/plugin-search";
+import { viteBundler } from "@vuepress/bundler-vite";
 
 
 export default defineUserConfig({
@@ -8,6 +9,7 @@ export default defineUserConfig({
   lang: "en-US",
   title: "BCGov Block Theme",
   description: "BCGov Block Theme Documentation",
+  bundler: viteBundler({}),
   theme: defaultTheme({
     editLink: false,
     lastUpdated: true,

--- a/documentation/package-lock.json
+++ b/documentation/package-lock.json
@@ -1,22 +1,24 @@
 {
   "name": "developer-documentation",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "developer-documentation",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "devDependencies": {
-        "@vuepress/plugin-search": "^2.0.0-rc",
-        "vuepress": "^2.0.0-rc"
+        "@vuepress/bundler-vite": "^2.0.0-rc.0",
+        "@vuepress/plugin-search": "^2.0.0-rc.0",
+        "@vuepress/theme-default": "^2.0.0-rc.0",
+        "vuepress": "^2.0.0-rc.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.5.tgz",
-      "integrity": "sha512-hOOqoiNXrmGdFbhgCzu6GiURxUgM27Xwd/aPuu8RfHEZPBzL1Z54okAHAQjXfcQNwvrlkAmAp4SlRTZ45vlthQ==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.9.tgz",
+      "integrity": "sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -25,10 +27,26 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
+      "integrity": "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.8.tgz",
-      "integrity": "sha512-31E2lxlGM1KEfivQl8Yf5aYU/mflz9g06H6S15ITUFQueMFtFjESRMoDSkvMo8thYvLBax+VKTPlpnx+sPicOA==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
+      "integrity": "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==",
       "cpu": [
         "arm"
       ],
@@ -42,9 +60,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.8.tgz",
-      "integrity": "sha512-B8JbS61bEunhfx8kasogFENgQfr/dIp+ggYXwTqdbMAgGDhRa3AaPpQMuQU0rNxDLECj6FhDzk1cF9WHMVwrtA==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz",
+      "integrity": "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==",
       "cpu": [
         "arm64"
       ],
@@ -58,9 +76,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.8.tgz",
-      "integrity": "sha512-rdqqYfRIn4jWOp+lzQttYMa2Xar3OK9Yt2fhOhzFXqg0rVWEfSclJvZq5fZslnz6ypHvVf3CT7qyf0A5pM682A==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz",
+      "integrity": "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==",
       "cpu": [
         "x64"
       ],
@@ -74,9 +92,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.8.tgz",
-      "integrity": "sha512-RQw9DemMbIq35Bprbboyf8SmOr4UXsRVxJ97LgB55VKKeJOOdvsIPy0nFyF2l8U+h4PtBx/1kRf0BelOYCiQcw==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
+      "integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
       "cpu": [
         "arm64"
       ],
@@ -90,9 +108,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.8.tgz",
-      "integrity": "sha512-3sur80OT9YdeZwIVgERAysAbwncom7b4bCI2XKLjMfPymTud7e/oY4y+ci1XVp5TfQp/bppn7xLw1n/oSQY3/Q==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz",
+      "integrity": "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==",
       "cpu": [
         "x64"
       ],
@@ -106,9 +124,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.8.tgz",
-      "integrity": "sha512-WAnPJSDattvS/XtPCTj1tPoTxERjcTpH6HsMr6ujTT+X6rylVe8ggxk8pVxzf5U1wh5sPODpawNicF5ta/9Tmw==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz",
+      "integrity": "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==",
       "cpu": [
         "arm64"
       ],
@@ -122,9 +140,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.8.tgz",
-      "integrity": "sha512-ICvZyOplIjmmhjd6mxi+zxSdpPTKFfyPPQMQTK/w+8eNK6WV01AjIztJALDtwNNfFhfZLux0tZLC+U9nSyA5Zg==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz",
+      "integrity": "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==",
       "cpu": [
         "x64"
       ],
@@ -138,9 +156,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.8.tgz",
-      "integrity": "sha512-H4vmI5PYqSvosPaTJuEppU9oz1dq2A7Mr2vyg5TF9Ga+3+MGgBdGzcyBP7qK9MrwFQZlvNyJrvz6GuCaj3OukQ==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz",
+      "integrity": "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==",
       "cpu": [
         "arm"
       ],
@@ -154,9 +172,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.8.tgz",
-      "integrity": "sha512-z1zMZivxDLHWnyGOctT9JP70h0beY54xDDDJt4VpTX+iwA77IFsE1vCXWmprajJGa+ZYSqkSbRQ4eyLCpCmiCQ==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz",
+      "integrity": "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==",
       "cpu": [
         "arm64"
       ],
@@ -170,9 +188,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.8.tgz",
-      "integrity": "sha512-1a8suQiFJmZz1khm/rDglOc8lavtzEMRo0v6WhPgxkrjcU0LkHj+TwBrALwoz/OtMExvsqbbMI0ChyelKabSvQ==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz",
+      "integrity": "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==",
       "cpu": [
         "ia32"
       ],
@@ -186,9 +204,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.8.tgz",
-      "integrity": "sha512-fHZWS2JJxnXt1uYJsDv9+b60WCc2RlvVAy1F76qOLtXRO+H4mjt3Tr6MJ5l7Q78X8KgCFudnTuiQRBhULUyBKQ==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz",
+      "integrity": "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==",
       "cpu": [
         "loong64"
       ],
@@ -202,9 +220,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.8.tgz",
-      "integrity": "sha512-Wy/z0EL5qZYLX66dVnEg9riiwls5IYnziwuju2oUiuxVc+/edvqXa04qNtbrs0Ukatg5HEzqT94Zs7J207dN5Q==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz",
+      "integrity": "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==",
       "cpu": [
         "mips64el"
       ],
@@ -218,9 +236,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.8.tgz",
-      "integrity": "sha512-ETaW6245wK23YIEufhMQ3HSeHO7NgsLx8gygBVldRHKhOlD1oNeNy/P67mIh1zPn2Hr2HLieQrt6tWrVwuqrxg==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz",
+      "integrity": "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==",
       "cpu": [
         "ppc64"
       ],
@@ -234,9 +252,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.8.tgz",
-      "integrity": "sha512-T2DRQk55SgoleTP+DtPlMrxi/5r9AeFgkhkZ/B0ap99zmxtxdOixOMI570VjdRCs9pE4Wdkz7JYrsPvsl7eESg==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz",
+      "integrity": "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==",
       "cpu": [
         "riscv64"
       ],
@@ -250,9 +268,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.8.tgz",
-      "integrity": "sha512-NPxbdmmo3Bk7mbNeHmcCd7R7fptJaczPYBaELk6NcXxy7HLNyWwCyDJ/Xx+/YcNH7Im5dHdx9gZ5xIwyliQCbg==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz",
+      "integrity": "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==",
       "cpu": [
         "s390x"
       ],
@@ -266,9 +284,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.8.tgz",
-      "integrity": "sha512-lytMAVOM3b1gPypL2TRmZ5rnXl7+6IIk8uB3eLsV1JwcizuolblXRrc5ShPrO9ls/b+RTp+E6gbsuLWHWi2zGg==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz",
+      "integrity": "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==",
       "cpu": [
         "x64"
       ],
@@ -282,9 +300,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.8.tgz",
-      "integrity": "sha512-hvWVo2VsXz/8NVt1UhLzxwAfo5sioj92uo0bCfLibB0xlOmimU/DeAEsQILlBQvkhrGjamP0/el5HU76HAitGw==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
+      "integrity": "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==",
       "cpu": [
         "x64"
       ],
@@ -298,9 +316,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.8.tgz",
-      "integrity": "sha512-/7Y7u77rdvmGTxR83PgaSvSBJCC2L3Kb1M/+dmSIvRvQPXXCuC97QAwMugBNG0yGcbEGfFBH7ojPzAOxfGNkwQ==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
+      "integrity": "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==",
       "cpu": [
         "x64"
       ],
@@ -314,9 +332,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.8.tgz",
-      "integrity": "sha512-9Lc4s7Oi98GqFA4HzA/W2JHIYfnXbUYgekUP/Sm4BG9sfLjyv6GKKHKKVs83SMicBF2JwAX6A1PuOLMqpD001w==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz",
+      "integrity": "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==",
       "cpu": [
         "x64"
       ],
@@ -330,9 +348,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.8.tgz",
-      "integrity": "sha512-rq6WzBGjSzihI9deW3fC2Gqiak68+b7qo5/3kmB6Gvbh/NYPA0sJhrnp7wgV4bNwjqM+R2AApXGxMO7ZoGhIJg==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz",
+      "integrity": "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==",
       "cpu": [
         "arm64"
       ],
@@ -346,9 +364,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.8.tgz",
-      "integrity": "sha512-AIAbverbg5jMvJznYiGhrd3sumfwWs8572mIJL5NQjJa06P8KfCPWZQ0NwZbPQnbQi9OWSZhFVSUWjjIrn4hSw==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz",
+      "integrity": "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==",
       "cpu": [
         "ia32"
       ],
@@ -362,9 +380,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.8.tgz",
-      "integrity": "sha512-bfZ0cQ1uZs2PqpulNL5j/3w+GDhP36k1K5c38QdQg+Swy51jFZWWeIkteNsufkQxp986wnqRRsb/bHbY1WQ7TA==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz",
+      "integrity": "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==",
       "cpu": [
         "x64"
       ],
@@ -384,89 +402,89 @@
       "dev": true
     },
     "node_modules/@mdit-vue/plugin-component": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-component/-/plugin-component-1.0.0.tgz",
-      "integrity": "sha512-ZXsJwxkG5yyTHARIYbR74cT4AZ0SfMokFFjiHYCbypHIeYWgJhso4+CZ8+3V9EWFG3EHlGoKNGqKp9chHnqntQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-component/-/plugin-component-2.0.0.tgz",
+      "integrity": "sha512-cTRxlocav/+mfgDcp0P2z/gWuWBez+iNuN4D+b74LpX4AR6UAx2ZvWtCrUZ8VXrO4eCt1/G0YC/Af7mpIb3aoQ==",
       "dev": true,
       "dependencies": {
-        "@types/markdown-it": "^13.0.1",
-        "markdown-it": "^13.0.1"
+        "@types/markdown-it": "^13.0.7",
+        "markdown-it": "^14.0.0"
       }
     },
     "node_modules/@mdit-vue/plugin-frontmatter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-frontmatter/-/plugin-frontmatter-1.0.0.tgz",
-      "integrity": "sha512-MMA7Ny+YPZA7eDOY1t4E+rKuEWO39mzDdP/M68fKdXJU6VfcGkPr7gnpnJfW2QBJ5qIvMrK/3lDAA2JBy5TfpA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-frontmatter/-/plugin-frontmatter-2.0.0.tgz",
+      "integrity": "sha512-/LrT6E60QI4XV4mqx3J87hqYXlR7ZyMvndmftR2RGz7cRAwa/xL+kyFLlgrMxkBIKitOShKa3LS/9Ov9b0fU+g==",
       "dev": true,
       "dependencies": {
-        "@mdit-vue/types": "1.0.0",
-        "@types/markdown-it": "^13.0.1",
+        "@mdit-vue/types": "2.0.0",
+        "@types/markdown-it": "^13.0.7",
         "gray-matter": "^4.0.3",
-        "markdown-it": "^13.0.1"
+        "markdown-it": "^14.0.0"
       }
     },
     "node_modules/@mdit-vue/plugin-headers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-headers/-/plugin-headers-1.0.0.tgz",
-      "integrity": "sha512-0rK/iKy6x13d/Pp5XxdLBshTD0+YjZvtHIaIV+JO+/H2WnOv7oaRgs48G5d44z3XJVUE2u6fNnTlI169fef0/A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-headers/-/plugin-headers-2.0.0.tgz",
+      "integrity": "sha512-ITMMPCnLEYHHgj3XEUL2l75jsNn8guxNqr26YrMSi1f5zcgq4XVy1LIvfwvJ1puqM6Cc5v4BHk3oAyorAi7l1A==",
       "dev": true,
       "dependencies": {
-        "@mdit-vue/shared": "1.0.0",
-        "@mdit-vue/types": "1.0.0",
-        "@types/markdown-it": "^13.0.1",
-        "markdown-it": "^13.0.1"
+        "@mdit-vue/shared": "2.0.0",
+        "@mdit-vue/types": "2.0.0",
+        "@types/markdown-it": "^13.0.7",
+        "markdown-it": "^14.0.0"
       }
     },
     "node_modules/@mdit-vue/plugin-sfc": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-sfc/-/plugin-sfc-1.0.0.tgz",
-      "integrity": "sha512-agMUe0fY4YHxsZivSvplBwRwrFvsIf/JNUJCAYq1+2Sg9+2hviTBZwjZDxYqHDHOVLtiNr+wuo68tE24mAx3AQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-sfc/-/plugin-sfc-2.0.0.tgz",
+      "integrity": "sha512-OXrMXOyk0iwdIou2jRoIHIbjskwghkO14C9/OjgVHXSSX+iM/WQ4l4yi1aWmNlbQNjtP8IXcVAyJB9K0DFYmLg==",
       "dev": true,
       "dependencies": {
-        "@mdit-vue/types": "1.0.0",
-        "@types/markdown-it": "^13.0.1",
-        "markdown-it": "^13.0.1"
+        "@mdit-vue/types": "2.0.0",
+        "@types/markdown-it": "^13.0.7",
+        "markdown-it": "^14.0.0"
       }
     },
     "node_modules/@mdit-vue/plugin-title": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-title/-/plugin-title-1.0.0.tgz",
-      "integrity": "sha512-8yC60fCZ95xcJ/cvJH4Lv43Rs4k+33UGyKrRWj5J8TNyMwUyGcwur0XyPM+ffJH4/Bzq4myZLsj/TTFSkXRxvw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-title/-/plugin-title-2.0.0.tgz",
+      "integrity": "sha512-eqBoETPVkMXNLvwFshz/A2+Cz81VB5HEkXDm0tt6RBW/rTvnoWmGJ1Z+mvcjR5ck5W4nYdIyT68oHxX2JI2M4g==",
       "dev": true,
       "dependencies": {
-        "@mdit-vue/shared": "1.0.0",
-        "@mdit-vue/types": "1.0.0",
-        "@types/markdown-it": "^13.0.1",
-        "markdown-it": "^13.0.1"
+        "@mdit-vue/shared": "2.0.0",
+        "@mdit-vue/types": "2.0.0",
+        "@types/markdown-it": "^13.0.7",
+        "markdown-it": "^14.0.0"
       }
     },
     "node_modules/@mdit-vue/plugin-toc": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-toc/-/plugin-toc-1.0.0.tgz",
-      "integrity": "sha512-WN8blfX0X/5Nolic0ClDWP7eVo9IB+U4g0jbycX3lolIZX5Bai1UpsD3QYZr5VVsPbQJMKMGvTrCEtCNTGvyWQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-toc/-/plugin-toc-2.0.0.tgz",
+      "integrity": "sha512-PKQ8sZna3D5chTnt2lxL+ddpyXd++6Nyc0l8VXCeDgStlySQwiP9jaLeeC88oqY4BtRu4cAmILmxDrvuX0Rrdg==",
       "dev": true,
       "dependencies": {
-        "@mdit-vue/shared": "1.0.0",
-        "@mdit-vue/types": "1.0.0",
-        "@types/markdown-it": "^13.0.1",
-        "markdown-it": "^13.0.1"
+        "@mdit-vue/shared": "2.0.0",
+        "@mdit-vue/types": "2.0.0",
+        "@types/markdown-it": "^13.0.7",
+        "markdown-it": "^14.0.0"
       }
     },
     "node_modules/@mdit-vue/shared": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@mdit-vue/shared/-/shared-1.0.0.tgz",
-      "integrity": "sha512-nbYBfmEi+pR2Lm0Z6TMVX2/iBjfr/kGEsHW8CC0rQw+3+sG5dY6VG094HuFAkiAmmvZx9DZZb+7ZMWp9vkwCRw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/shared/-/shared-2.0.0.tgz",
+      "integrity": "sha512-PdxpQpbyTazeo2JT87qms6RPZIzyJd+gwuB+1jSwLDI7+0u5g79y2XgTAbZromSVgY2f3UU5HWdwaLbV9w4uOw==",
       "dev": true,
       "dependencies": {
-        "@mdit-vue/types": "1.0.0",
-        "@types/markdown-it": "^13.0.1",
-        "markdown-it": "^13.0.1"
+        "@mdit-vue/types": "2.0.0",
+        "@types/markdown-it": "^13.0.7",
+        "markdown-it": "^14.0.0"
       }
     },
     "node_modules/@mdit-vue/types": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@mdit-vue/types/-/types-1.0.0.tgz",
-      "integrity": "sha512-xeF5+sHLzRNF7plbksywKCph4qli20l72of2fMlZQQ7RECvXYrRkE9+bjRFQCyULC7B8ydUYbpbkux5xJlVWyw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-1BeEB+DbtmDMUAfvbNUj5Hso8cSl2sBVK2iTyOMAqhfDVLdh+/9+D0JmQHaCeUk/vuJoMhOwbweZvh55wHxm4w==",
       "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -505,9 +523,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.6.1.tgz",
-      "integrity": "sha512-0WQ0ouLejaUCRsL93GD4uft3rOmB8qoQMU05Kb8CmMtMBe7XUDLAltxVZI1q6byNqEtU7N1ZX1Vw5lIpgulLQA==",
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.6.tgz",
+      "integrity": "sha512-MVNXSSYN6QXOulbHpLMKYi60ppyO13W9my1qogeiAqtjb2yR4LSmfU2+POvDkLzhjYLXz9Rf9+9a3zFHW1Lecg==",
       "cpu": [
         "arm"
       ],
@@ -518,9 +536,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.6.1.tgz",
-      "integrity": "sha512-1TKm25Rn20vr5aTGGZqo6E4mzPicCUD79k17EgTLAsXc1zysyi4xXKACfUbwyANEPAEIxkzwue6JZ+stYzWUTA==",
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.6.tgz",
+      "integrity": "sha512-T14aNLpqJ5wzKNf5jEDpv5zgyIqcpn1MlwCrUXLrwoADr2RkWA0vOWP4XxbO9aiO3dvMCQICZdKeDrFl7UMClw==",
       "cpu": [
         "arm64"
       ],
@@ -531,9 +549,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.6.1.tgz",
-      "integrity": "sha512-cEXJQY/ZqMACb+nxzDeX9IPLAg7S94xouJJCNVE5BJM8JUEP4HeTF+ti3cmxWeSJo+5D+o8Tc0UAWUkfENdeyw==",
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.6.tgz",
+      "integrity": "sha512-CqNNAyhRkTbo8VVZ5R85X73H3R5NX9ONnKbXuHisGWC0qRbTTxnF1U4V9NafzJbgGM0sHZpdO83pLPzq8uOZFw==",
       "cpu": [
         "arm64"
       ],
@@ -544,9 +562,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.6.1.tgz",
-      "integrity": "sha512-LoSU9Xu56isrkV2jLldcKspJ7sSXmZWkAxg7sW/RfF7GS4F5/v4EiqKSMCFbZtDu2Nc1gxxFdQdKwkKS4rwxNg==",
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.6.tgz",
+      "integrity": "sha512-zRDtdJuRvA1dc9Mp6BWYqAsU5oeLixdfUvkTHuiYOHwqYuQ4YgSmi6+/lPvSsqc/I0Omw3DdICx4Tfacdzmhog==",
       "cpu": [
         "x64"
       ],
@@ -557,9 +575,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.6.1.tgz",
-      "integrity": "sha512-EfI3hzYAy5vFNDqpXsNxXcgRDcFHUWSx5nnRSCKwXuQlI5J9dD84g2Usw81n3FLBNsGCegKGwwTVsSKK9cooSQ==",
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.6.tgz",
+      "integrity": "sha512-oNk8YXDDnNyG4qlNb6is1ojTOGL/tRhbbKeE/YuccItzerEZT68Z9gHrY3ROh7axDc974+zYAPxK5SH0j/G+QQ==",
       "cpu": [
         "arm"
       ],
@@ -570,9 +588,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.6.1.tgz",
-      "integrity": "sha512-9lhc4UZstsegbNLhH0Zu6TqvDfmhGzuCWtcTFXY10VjLLUe4Mr0Ye2L3rrtHaDd/J5+tFMEuo5LTCSCMXWfUKw==",
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.6.tgz",
+      "integrity": "sha512-Z3O60yxPtuCYobrtzjo0wlmvDdx2qZfeAWTyfOjEDqd08kthDKexLpV97KfAeUXPosENKd8uyJMRDfFMxcYkDQ==",
       "cpu": [
         "arm64"
       ],
@@ -583,9 +601,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.6.1.tgz",
-      "integrity": "sha512-FfoOK1yP5ksX3wwZ4Zk1NgyGHZyuRhf99j64I5oEmirV8EFT7+OhUZEnP+x17lcP/QHJNWGsoJwrz4PJ9fBEXw==",
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.6.tgz",
+      "integrity": "sha512-gpiG0qQJNdYEVad+1iAsGAbgAnZ8j07FapmnIAQgODKcOTjLEWM9sRb+MbQyVsYCnA0Im6M6QIq6ax7liws6eQ==",
       "cpu": [
         "arm64"
       ],
@@ -595,10 +613,23 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.6.tgz",
+      "integrity": "sha512-+uCOcvVmFUYvVDr27aiyun9WgZk0tXe7ThuzoUTAukZJOwS5MrGbmSlNOhx1j80GdpqbOty05XqSl5w4dQvcOA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.6.1.tgz",
-      "integrity": "sha512-DNGZvZDO5YF7jN5fX8ZqmGLjZEXIJRdJEdTFMhiyXqyXubBa0WVLDWSNlQ5JR2PNgDbEV1VQowhVRUh+74D+RA==",
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.6.tgz",
+      "integrity": "sha512-HUNqM32dGzfBKuaDUBqFB7tP6VMN74eLZ33Q9Y1TBqRDn+qDonkAUyKWwF9BR9unV7QUzffLnz9GrnKvMqC/fw==",
       "cpu": [
         "x64"
       ],
@@ -609,9 +640,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.6.1.tgz",
-      "integrity": "sha512-RkJVNVRM+piYy87HrKmhbexCHg3A6Z6MU0W9GHnJwBQNBeyhCJG9KDce4SAMdicQnpURggSvtbGo9xAWOfSvIQ==",
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.6.tgz",
+      "integrity": "sha512-ch7M+9Tr5R4FK40FHQk8VnML0Szi2KRujUgHXd/HjuH9ifH72GUmw6lStZBo3c3GB82vHa0ZoUfjfcM7JiiMrQ==",
       "cpu": [
         "x64"
       ],
@@ -622,9 +653,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.6.1.tgz",
-      "integrity": "sha512-v2FVT6xfnnmTe3W9bJXl6r5KwJglMK/iRlkKiIFfO6ysKs0rDgz7Cwwf3tjldxQUrHL9INT/1r4VA0n9L/F1vQ==",
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.6.tgz",
+      "integrity": "sha512-VD6qnR99dhmTQ1mJhIzXsRcTBvTjbfbGGwKAHcu+52cVl15AC/kplkhxzW/uT0Xl62Y/meBKDZvoJSJN+vTeGA==",
       "cpu": [
         "arm64"
       ],
@@ -635,9 +666,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.6.1.tgz",
-      "integrity": "sha512-YEeOjxRyEjqcWphH9dyLbzgkF8wZSKAKUkldRY6dgNR5oKs2LZazqGB41cWJ4Iqqcy9/zqYgmzBkRoVz3Q9MLw==",
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.6.tgz",
+      "integrity": "sha512-J9AFDq/xiRI58eR2NIDfyVmTYGyIZmRcvcAoJ48oDld/NTR8wyiPUu2X/v1navJ+N/FGg68LEbX3Ejd6l8B7MQ==",
       "cpu": [
         "ia32"
       ],
@@ -648,9 +679,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.6.1.tgz",
-      "integrity": "sha512-0zfTlFAIhgz8V2G8STq8toAjsYYA6eci1hnXuyOTUFnymrtJwnS6uGKiv3v5UrPZkBlamLvrLV2iiaeqCKzb0A==",
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.6.tgz",
+      "integrity": "sha512-jqzNLhNDvIZOrt69Ce4UjGRpXJBzhUBzawMwnaDAwyHriki3XollsewxWzOzz+4yOFDkuJHtTsZFwMxhYJWmLQ==",
       "cpu": [
         "x64"
       ],
@@ -680,6 +711,12 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
     },
     "node_modules/@types/fs-extra": {
       "version": "11.0.4",
@@ -744,9 +781,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.10.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.1.tgz",
-      "integrity": "sha512-T2qwhjWwGH81vUEx4EXmBKsTJRXFXNZTL4v0gi01+zyBmCwzE6TyHszqX01m+QHTEq+EZNo13NeJIdEqf+Myrg==",
+      "version": "20.11.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.7.tgz",
+      "integrity": "sha512-GPmeN1C3XAyV5uybAf4cMLWT9fDWcmQhZVtMFu7OR32WjrqGG+Wnk2V1d0bmtUyE/Zy1QJ9BxyiTih9z8Oks8A==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -759,66 +796,66 @@
       "dev": true
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.5.0.tgz",
-      "integrity": "sha512-a2WSpP8X8HTEww/U00bU4mX1QpLINNuz/2KMNpLsdu3BzOpak3AGI1CJYBTXcc4SPhaD0eNRUp7IyQK405L5dQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.0.3.tgz",
+      "integrity": "sha512-b8S5dVS40rgHdDrw+DQi/xOM9ed+kSRZzfm1T74bMmBDCd8XO87NKlFYInzCtwvtWwXZvo1QxE2OSspTATWrbA==",
       "dev": true,
       "engines": {
-        "node": "^14.18.0 || >=16.0.0"
+        "node": "^18.0.0 || >=20.0.0"
       },
       "peerDependencies": {
-        "vite": "^4.0.0 || ^5.0.0",
+        "vite": "^5.0.0",
         "vue": "^3.2.25"
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.9.tgz",
-      "integrity": "sha512-+/Lf68Vr/nFBA6ol4xOtJrW+BQWv3QWKfRwGSm70jtXwfhZNF4R/eRgyVJYoxFRhdCTk/F6g99BP0ffPgZihfQ==",
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.15.tgz",
+      "integrity": "sha512-XcJQVOaxTKCnth1vCxEChteGuwG6wqnUHxAm1DO3gCz0+uXKaJNx8/digSz4dLALCy8n2lKq24jSUs8segoqIw==",
       "dev": true,
       "dependencies": {
-        "@babel/parser": "^7.23.3",
-        "@vue/shared": "3.3.9",
+        "@babel/parser": "^7.23.6",
+        "@vue/shared": "3.4.15",
+        "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.0.2"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.9.tgz",
-      "integrity": "sha512-nfWubTtLXuT4iBeDSZ5J3m218MjOy42Vp2pmKVuBKo2/BLcrFUX8nCSr/bKRFiJ32R8qbdnnnBgRn9AdU5v0Sg==",
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.15.tgz",
+      "integrity": "sha512-wox0aasVV74zoXyblarOM3AZQz/Z+OunYcIHe1OsGclCHt8RsRm04DObjefaI82u6XDzv+qGWZ24tIsRAIi5MQ==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-core": "3.3.9",
-        "@vue/shared": "3.3.9"
+        "@vue/compiler-core": "3.4.15",
+        "@vue/shared": "3.4.15"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.9.tgz",
-      "integrity": "sha512-wy0CNc8z4ihoDzjASCOCsQuzW0A/HP27+0MDSSICMjVIFzk/rFViezkR3dzH+miS2NDEz8ywMdbjO5ylhOLI2A==",
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.15.tgz",
+      "integrity": "sha512-LCn5M6QpkpFsh3GQvs2mJUOAlBQcCco8D60Bcqmf3O3w5a+KWS5GvYbrrJBkgvL1BDnTp+e8q0lXCLgHhKguBA==",
       "dev": true,
       "dependencies": {
-        "@babel/parser": "^7.23.3",
-        "@vue/compiler-core": "3.3.9",
-        "@vue/compiler-dom": "3.3.9",
-        "@vue/compiler-ssr": "3.3.9",
-        "@vue/reactivity-transform": "3.3.9",
-        "@vue/shared": "3.3.9",
+        "@babel/parser": "^7.23.6",
+        "@vue/compiler-core": "3.4.15",
+        "@vue/compiler-dom": "3.4.15",
+        "@vue/compiler-ssr": "3.4.15",
+        "@vue/shared": "3.4.15",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.5",
-        "postcss": "^8.4.31",
+        "postcss": "^8.4.33",
         "source-map-js": "^1.0.2"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.9.tgz",
-      "integrity": "sha512-NO5oobAw78R0G4SODY5A502MGnDNiDjf6qvhn7zD7TJGc8XDeIEw4fg6JU705jZ/YhuokBKz0A5a/FL/XZU73g==",
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.15.tgz",
+      "integrity": "sha512-1jdeQyiGznr8gjFDadVmOJqZiLNSsMa5ZgqavkPZ8O2wjHv0tVuAEsw5hTdUoUW4232vpBbL/wJhzVW/JwY1Uw==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.3.9",
-        "@vue/shared": "3.3.9"
+        "@vue/compiler-dom": "3.4.15",
+        "@vue/shared": "3.4.15"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -828,336 +865,318 @@
       "dev": true
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.9.tgz",
-      "integrity": "sha512-VmpIqlNp+aYDg2X0xQhJqHx9YguOmz2UxuUJDckBdQCNkipJvfk9yA75woLWElCa0Jtyec3lAAt49GO0izsphw==",
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.15.tgz",
+      "integrity": "sha512-55yJh2bsff20K5O84MxSvXKPHHt17I2EomHznvFiJCAZpJTNW8IuLj1xZWMLELRhBK3kkFV/1ErZGHJfah7i7w==",
       "dev": true,
       "dependencies": {
-        "@vue/shared": "3.3.9"
-      }
-    },
-    "node_modules/@vue/reactivity-transform": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.9.tgz",
-      "integrity": "sha512-HnUFm7Ry6dFa4Lp63DAxTixUp8opMtQr6RxQCpDI1vlh12rkGIeYqMvJtK+IKyEfEOa2I9oCkD1mmsPdaGpdVg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/parser": "^7.23.3",
-        "@vue/compiler-core": "3.3.9",
-        "@vue/shared": "3.3.9",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.5"
+        "@vue/shared": "3.4.15"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.9.tgz",
-      "integrity": "sha512-xxaG9KvPm3GTRuM4ZyU8Tc+pMVzcu6eeoSRQJ9IE7NmCcClW6z4B3Ij6L4EDl80sxe/arTtQ6YmgiO4UZqRc+w==",
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.15.tgz",
+      "integrity": "sha512-6E3by5m6v1AkW0McCeAyhHTw+3y17YCOKG0U0HDKDscV4Hs0kgNT5G+GCHak16jKgcCDHpI9xe5NKb8sdLCLdw==",
       "dev": true,
       "dependencies": {
-        "@vue/reactivity": "3.3.9",
-        "@vue/shared": "3.3.9"
+        "@vue/reactivity": "3.4.15",
+        "@vue/shared": "3.4.15"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.9.tgz",
-      "integrity": "sha512-e7LIfcxYSWbV6BK1wQv9qJyxprC75EvSqF/kQKe6bdZEDNValzeRXEVgiX7AHI6hZ59HA4h7WT5CGvm69vzJTQ==",
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.15.tgz",
+      "integrity": "sha512-EVW8D6vfFVq3V/yDKNPBFkZKGMFSvZrUQmx196o/v2tHKdwWdiZjYUBS+0Ez3+ohRyF8Njwy/6FH5gYJ75liUw==",
       "dev": true,
       "dependencies": {
-        "@vue/runtime-core": "3.3.9",
-        "@vue/shared": "3.3.9",
-        "csstype": "^3.1.2"
+        "@vue/runtime-core": "3.4.15",
+        "@vue/shared": "3.4.15",
+        "csstype": "^3.1.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.9.tgz",
-      "integrity": "sha512-w0zT/s5l3Oa3ZjtLW88eO4uV6AQFqU8X5GOgzq7SkQQu6vVr+8tfm+OI2kDBplS/W/XgCBuFXiPw6T5EdwXP0A==",
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.15.tgz",
+      "integrity": "sha512-3HYzaidu9cHjrT+qGUuDhFYvF/j643bHC6uUN9BgM11DVy+pM6ATsG6uPBLnkwOgs7BpJABReLmpL3ZPAsUaqw==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-ssr": "3.3.9",
-        "@vue/shared": "3.3.9"
+        "@vue/compiler-ssr": "3.4.15",
+        "@vue/shared": "3.4.15"
       },
       "peerDependencies": {
-        "vue": "3.3.9"
+        "vue": "3.4.15"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.9.tgz",
-      "integrity": "sha512-ZE0VTIR0LmYgeyhurPTpy4KzKsuDyQbMSdM49eKkMnT5X4VfFBLysMzjIZhLEFQYjjOVVfbvUDHckwjDFiO2eA==",
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.15.tgz",
+      "integrity": "sha512-KzfPTxVaWfB+eGcGdbSf4CWdaXcGDqckoeXUh7SB3fZdEtzPCK2Vq9B/lRRL3yutax/LWITz+SwvgyOxz5V75g==",
       "dev": true
     },
     "node_modules/@vuepress/bundler-vite": {
-      "version": "2.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@vuepress/bundler-vite/-/bundler-vite-2.0.0-rc.0.tgz",
-      "integrity": "sha512-rX8S8IYpqqlJfNPstS/joorpxXx/4WuE7+gDM31i2HUrxOKGZVzq8ZsRRRU2UdoTwHZSd3LpUS4sMtxE5xLK1A==",
+      "version": "2.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@vuepress/bundler-vite/-/bundler-vite-2.0.0-rc.2.tgz",
+      "integrity": "sha512-bjkn0krtucciUkGGdckCkGGg+wlv3Pj7s1lO/ChACLQncDwc3GgMTuMm0JyaCDKzTXE8sufjHHGWMftRL8qFOg==",
       "dev": true,
       "dependencies": {
-        "@vitejs/plugin-vue": "^4.5.0",
-        "@vuepress/client": "2.0.0-rc.0",
-        "@vuepress/core": "2.0.0-rc.0",
-        "@vuepress/shared": "2.0.0-rc.0",
-        "@vuepress/utils": "2.0.0-rc.0",
-        "autoprefixer": "^10.4.16",
+        "@vitejs/plugin-vue": "^5.0.3",
+        "@vuepress/client": "2.0.0-rc.2",
+        "@vuepress/core": "2.0.0-rc.2",
+        "@vuepress/shared": "2.0.0-rc.2",
+        "@vuepress/utils": "2.0.0-rc.2",
+        "autoprefixer": "^10.4.17",
         "connect-history-api-fallback": "^2.0.0",
-        "postcss": "^8.4.31",
-        "postcss-load-config": "^4.0.1",
-        "rollup": "^4.4.1",
-        "vite": "~5.0.0",
-        "vue": "^3.3.8",
+        "postcss": "^8.4.33",
+        "postcss-load-config": "^5.0.2",
+        "rollup": "^4.9.6",
+        "vite": "~5.0.12",
+        "vue": "^3.4.15",
         "vue-router": "^4.2.5"
       }
     },
     "node_modules/@vuepress/cli": {
-      "version": "2.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@vuepress/cli/-/cli-2.0.0-rc.0.tgz",
-      "integrity": "sha512-XWSIFO9iOR7N4O2lXIwS5vZuLjU9WU/aGAtmhMWEMxrdMx7TQaJbgrfpTUEbHMf+cPI1DXBbUbtmkqIvtfOV0w==",
+      "version": "2.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@vuepress/cli/-/cli-2.0.0-rc.2.tgz",
+      "integrity": "sha512-a5qAtd6gNndNcqENBNkMn9xRDbb1B2kJ62dWUaE5KjhkM/Fed4CTvBTDd0qfYmwiwsSFPL08VWavo1FcdMNXsA==",
       "dev": true,
       "dependencies": {
-        "@vuepress/core": "2.0.0-rc.0",
-        "@vuepress/shared": "2.0.0-rc.0",
-        "@vuepress/utils": "2.0.0-rc.0",
+        "@vuepress/core": "2.0.0-rc.2",
+        "@vuepress/shared": "2.0.0-rc.2",
+        "@vuepress/utils": "2.0.0-rc.2",
         "cac": "^6.7.14",
         "chokidar": "^3.5.3",
         "envinfo": "^7.11.0",
-        "esbuild": "~0.19.5"
+        "esbuild": "~0.19.12"
       },
       "bin": {
         "vuepress-cli": "bin/vuepress.js"
       }
     },
     "node_modules/@vuepress/client": {
-      "version": "2.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@vuepress/client/-/client-2.0.0-rc.0.tgz",
-      "integrity": "sha512-TwQx8hJgYONYxX+QltZ2aw9O5Ym6SKelfiUduuIRb555B1gece/jSVap3H/ZwyBhpgJMtG4+/Mrmf8nlDSHjvw==",
+      "version": "2.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@vuepress/client/-/client-2.0.0-rc.2.tgz",
+      "integrity": "sha512-gQ4CfBhzWYOCW4OcAUd6S8Jr9m/8UkZZuN/70t12GltbX/cdm6zrGnf89GiVjgvoK8+OYoc7luoBuWbyc/X5sg==",
       "dev": true,
       "dependencies": {
         "@vue/devtools-api": "^6.5.1",
-        "@vuepress/shared": "2.0.0-rc.0",
-        "@vueuse/core": "^10.6.1",
-        "vue": "^3.3.8",
+        "@vuepress/shared": "2.0.0-rc.2",
+        "@vueuse/core": "^10.7.2",
+        "vue": "^3.4.15",
         "vue-router": "^4.2.5"
       }
     },
     "node_modules/@vuepress/core": {
-      "version": "2.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@vuepress/core/-/core-2.0.0-rc.0.tgz",
-      "integrity": "sha512-uoOaZP1MdxZYJIAJcRcmYKKeCIVnxZeOuLMOOB9CPuAKSalT1RvJ1lztw6RX3q9SPnlqtSZPQXDncPAZivw4pA==",
+      "version": "2.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@vuepress/core/-/core-2.0.0-rc.2.tgz",
+      "integrity": "sha512-C/bHG0y+v5oeCrfaesy2yFa0dyCah05g1w7vArZk8ABsVECjZKAC5/ev39UFQm2dCdNzsj2E3KgLIxYWqpcKeg==",
       "dev": true,
       "dependencies": {
-        "@vuepress/client": "2.0.0-rc.0",
-        "@vuepress/markdown": "2.0.0-rc.0",
-        "@vuepress/shared": "2.0.0-rc.0",
-        "@vuepress/utils": "2.0.0-rc.0",
-        "vue": "^3.3.8"
+        "@vuepress/client": "2.0.0-rc.2",
+        "@vuepress/markdown": "2.0.0-rc.2",
+        "@vuepress/shared": "2.0.0-rc.2",
+        "@vuepress/utils": "2.0.0-rc.2",
+        "vue": "^3.4.15"
       }
     },
     "node_modules/@vuepress/markdown": {
-      "version": "2.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@vuepress/markdown/-/markdown-2.0.0-rc.0.tgz",
-      "integrity": "sha512-USmqdKKMT6ZFHYRztTjKUlO8qgGfnEygMAAq4AzC/uYXiEfrbMBLAWJhteyGS56P3rGLj0OPAhksE681bX/wOg==",
+      "version": "2.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@vuepress/markdown/-/markdown-2.0.0-rc.2.tgz",
+      "integrity": "sha512-5/RmJnap+MGKxDhSO+Mv6zB8PoPHhhBujnNKKO3PnyfPrj0LyL0AuTm8m3Ea271wMp9956WINjw8jlpn+Z1sBg==",
       "dev": true,
       "dependencies": {
-        "@mdit-vue/plugin-component": "^1.0.0",
-        "@mdit-vue/plugin-frontmatter": "^1.0.0",
-        "@mdit-vue/plugin-headers": "^1.0.0",
-        "@mdit-vue/plugin-sfc": "^1.0.0",
-        "@mdit-vue/plugin-title": "^1.0.0",
-        "@mdit-vue/plugin-toc": "^1.0.0",
-        "@mdit-vue/shared": "^1.0.0",
-        "@mdit-vue/types": "^1.0.0",
-        "@types/markdown-it": "^13.0.6",
+        "@mdit-vue/plugin-component": "^2.0.0",
+        "@mdit-vue/plugin-frontmatter": "^2.0.0",
+        "@mdit-vue/plugin-headers": "^2.0.0",
+        "@mdit-vue/plugin-sfc": "^2.0.0",
+        "@mdit-vue/plugin-title": "^2.0.0",
+        "@mdit-vue/plugin-toc": "^2.0.0",
+        "@mdit-vue/shared": "^2.0.0",
+        "@mdit-vue/types": "^2.0.0",
+        "@types/markdown-it": "^13.0.7",
         "@types/markdown-it-emoji": "^2.0.4",
-        "@vuepress/shared": "2.0.0-rc.0",
-        "@vuepress/utils": "2.0.0-rc.0",
-        "markdown-it": "^13.0.2",
+        "@vuepress/shared": "2.0.0-rc.2",
+        "@vuepress/utils": "2.0.0-rc.2",
+        "markdown-it": "^14.0.0",
         "markdown-it-anchor": "^8.6.7",
-        "markdown-it-emoji": "^2.0.2",
-        "mdurl": "^1.0.1"
+        "markdown-it-emoji": "^3.0.0",
+        "mdurl": "^2.0.0"
       }
     },
     "node_modules/@vuepress/plugin-active-header-links": {
-      "version": "2.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-active-header-links/-/plugin-active-header-links-2.0.0-rc.0.tgz",
-      "integrity": "sha512-UJdXLYNGL5Wjy5YGY8M2QgqT75bZ95EHebbqGi8twBdIJE9O+bM+dPJyYtAk2PIVqFORiw3Hj+PchsNSxdn9+g==",
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-active-header-links/-/plugin-active-header-links-2.0.0-rc.1.tgz",
+      "integrity": "sha512-Ra5exai0mWH9uihzoVH8pje9XXll8zcICmDilTaYhir+KFw1VvKUFGLxLlEXuAMc06K4i25To2BzUVyce1Fijg==",
       "dev": true,
       "dependencies": {
-        "@vuepress/client": "2.0.0-rc.0",
-        "@vuepress/core": "2.0.0-rc.0",
-        "@vuepress/utils": "2.0.0-rc.0",
         "ts-debounce": "^4.0.0",
-        "vue": "^3.3.8",
-        "vue-router": "^4.2.5"
-      }
-    },
-    "node_modules/@vuepress/plugin-back-to-top": {
-      "version": "2.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-back-to-top/-/plugin-back-to-top-2.0.0-rc.0.tgz",
-      "integrity": "sha512-6GPfuzV5lkAnR00BxRUhqMXwMWt741alkq2R6bln4N8BneSOwEpX/7vi19MGf232aKdS/Va4pF5p0/nJ8Sed/g==",
-      "dev": true,
-      "dependencies": {
-        "@vuepress/client": "2.0.0-rc.0",
-        "@vuepress/core": "2.0.0-rc.0",
-        "@vuepress/utils": "2.0.0-rc.0",
-        "ts-debounce": "^4.0.0",
-        "vue": "^3.3.8"
-      }
-    },
-    "node_modules/@vuepress/plugin-container": {
-      "version": "2.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-container/-/plugin-container-2.0.0-rc.0.tgz",
-      "integrity": "sha512-b7vrLN11YE7qiUDPfA3N9P7Z8fupe9Wbcr9KAE/bmfZ9VT4d6kzpVyoU7XHi99XngitsmnkaXP4aBvBF1c2AnA==",
-      "dev": true,
-      "dependencies": {
-        "@types/markdown-it": "^13.0.6",
-        "@vuepress/core": "2.0.0-rc.0",
-        "@vuepress/markdown": "2.0.0-rc.0",
-        "@vuepress/shared": "2.0.0-rc.0",
-        "@vuepress/utils": "2.0.0-rc.0",
-        "markdown-it": "^13.0.2",
-        "markdown-it-container": "^3.0.0"
-      }
-    },
-    "node_modules/@vuepress/plugin-external-link-icon": {
-      "version": "2.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-external-link-icon/-/plugin-external-link-icon-2.0.0-rc.0.tgz",
-      "integrity": "sha512-o8bk0oIlj/BkKc02mq91XLDloq1VOz/8iNcRwKAeqBE6svXzdYiyoTGet0J/4iPuAetsCn75S57W6RioDJHMnQ==",
-      "dev": true,
-      "dependencies": {
-        "@vuepress/client": "2.0.0-rc.0",
-        "@vuepress/core": "2.0.0-rc.0",
-        "@vuepress/markdown": "2.0.0-rc.0",
-        "@vuepress/shared": "2.0.0-rc.0",
-        "@vuepress/utils": "2.0.0-rc.0",
-        "vue": "^3.3.8"
-      }
-    },
-    "node_modules/@vuepress/plugin-git": {
-      "version": "2.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-git/-/plugin-git-2.0.0-rc.0.tgz",
-      "integrity": "sha512-r7UF77vZxaYeJQLygzodKv+15z3/dTLuGp4VcYO21W6BlJZvd4u9zqgiV7A//bZQvK4+3Hprylr0G3KgXqMewA==",
-      "dev": true,
-      "dependencies": {
-        "@vuepress/core": "2.0.0-rc.0",
-        "@vuepress/utils": "2.0.0-rc.0",
-        "execa": "^8.0.1"
-      }
-    },
-    "node_modules/@vuepress/plugin-medium-zoom": {
-      "version": "2.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-medium-zoom/-/plugin-medium-zoom-2.0.0-rc.0.tgz",
-      "integrity": "sha512-peU1lYKsmKikIe/0pkJuHzD/k6xW2TuqdvKVhV4I//aOE1WxsREKJ4ACcldmoIsnysoDydAUqKT6xDPGyDsH2g==",
-      "dev": true,
-      "dependencies": {
-        "@vuepress/client": "2.0.0-rc.0",
-        "@vuepress/core": "2.0.0-rc.0",
-        "@vuepress/utils": "2.0.0-rc.0",
-        "medium-zoom": "^1.1.0",
-        "vue": "^3.3.8"
-      }
-    },
-    "node_modules/@vuepress/plugin-nprogress": {
-      "version": "2.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-nprogress/-/plugin-nprogress-2.0.0-rc.0.tgz",
-      "integrity": "sha512-rI+eK0Pg1KiZE+7hGmDUeSbgdWCid8Vnw0hFKNmjinDzGVmx4m03M6qfvclsI0SryH+lR7itZGLaR4gbTlrz/w==",
-      "dev": true,
-      "dependencies": {
-        "@vuepress/client": "2.0.0-rc.0",
-        "@vuepress/core": "2.0.0-rc.0",
-        "@vuepress/utils": "2.0.0-rc.0",
-        "vue": "^3.3.8",
-        "vue-router": "^4.2.5"
-      }
-    },
-    "node_modules/@vuepress/plugin-palette": {
-      "version": "2.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-palette/-/plugin-palette-2.0.0-rc.0.tgz",
-      "integrity": "sha512-wW70SCp3/K7s1lln5YQsBGTog2WXaQv5piva5zhXcQ47YGf4aAJpThDa5C/ot4HhkPOKn8Iz5s0ckxXZzW8DIg==",
-      "dev": true,
-      "dependencies": {
-        "@vuepress/core": "2.0.0-rc.0",
-        "@vuepress/utils": "2.0.0-rc.0",
-        "chokidar": "^3.5.3"
-      }
-    },
-    "node_modules/@vuepress/plugin-prismjs": {
-      "version": "2.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-prismjs/-/plugin-prismjs-2.0.0-rc.0.tgz",
-      "integrity": "sha512-c5WRI7+FhVjdbymOKQ8F2KY/Bnv7aQtWScVk8vCMUimNi7v7Wff/A/i3KSFNz/tge3LxiAeH/Dc2WS/OnQXwCg==",
-      "dev": true,
-      "dependencies": {
-        "@vuepress/core": "2.0.0-rc.0",
-        "prismjs": "^1.29.0"
-      }
-    },
-    "node_modules/@vuepress/plugin-search": {
-      "version": "2.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-search/-/plugin-search-2.0.0-rc.0.tgz",
-      "integrity": "sha512-1ikJUgIN+7QrcAftxpWUKTrNVHEN2+k/az0Sjz7Ok7EthMHcG6qQsIb+AoK4WIQMsJkwVPLxwym/M1FbBTZDWQ==",
-      "dev": true,
-      "dependencies": {
-        "@vuepress/client": "2.0.0-rc.0",
-        "@vuepress/core": "2.0.0-rc.0",
-        "@vuepress/shared": "2.0.0-rc.0",
-        "@vuepress/utils": "2.0.0-rc.0",
-        "chokidar": "^3.5.3",
-        "vue": "^3.3.8",
-        "vue-router": "^4.2.5"
-      }
-    },
-    "node_modules/@vuepress/plugin-theme-data": {
-      "version": "2.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-theme-data/-/plugin-theme-data-2.0.0-rc.0.tgz",
-      "integrity": "sha512-FXY3/Ml+rM6gNKvwdBF6vKAcwnSvtXCzKgQwJAw3ppQTKUkLcbOxqM+h4d8bzHWAAvdnEvQFug5uEZgWllBQbA==",
-      "dev": true,
-      "dependencies": {
-        "@vue/devtools-api": "^6.5.1",
-        "@vuepress/client": "2.0.0-rc.0",
-        "@vuepress/core": "2.0.0-rc.0",
-        "@vuepress/shared": "2.0.0-rc.0",
-        "@vuepress/utils": "2.0.0-rc.0",
-        "vue": "^3.3.8"
-      }
-    },
-    "node_modules/@vuepress/shared": {
-      "version": "2.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@vuepress/shared/-/shared-2.0.0-rc.0.tgz",
-      "integrity": "sha512-ikdSfjRv5LGM1iv4HHwF9P6gqTjaFCXKPK+hzlkHFHNZO1GLqk7/BPc4F51tAG1s8TcLhUZc+54LrfgS7PkXXA==",
-      "dev": true,
-      "dependencies": {
-        "@mdit-vue/types": "^1.0.0",
-        "@vue/shared": "^3.3.8"
-      }
-    },
-    "node_modules/@vuepress/theme-default": {
-      "version": "2.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@vuepress/theme-default/-/theme-default-2.0.0-rc.0.tgz",
-      "integrity": "sha512-I8Y08evDmMuD1jh3NftPpFFSlCWOizQDJLjN7EQwcg7jiAP4A7c2REo6nBN2EmP24Mi7UrRM+RnytHR5V+pElA==",
-      "dev": true,
-      "dependencies": {
-        "@vuepress/client": "2.0.0-rc.0",
-        "@vuepress/core": "2.0.0-rc.0",
-        "@vuepress/plugin-active-header-links": "2.0.0-rc.0",
-        "@vuepress/plugin-back-to-top": "2.0.0-rc.0",
-        "@vuepress/plugin-container": "2.0.0-rc.0",
-        "@vuepress/plugin-external-link-icon": "2.0.0-rc.0",
-        "@vuepress/plugin-git": "2.0.0-rc.0",
-        "@vuepress/plugin-medium-zoom": "2.0.0-rc.0",
-        "@vuepress/plugin-nprogress": "2.0.0-rc.0",
-        "@vuepress/plugin-palette": "2.0.0-rc.0",
-        "@vuepress/plugin-prismjs": "2.0.0-rc.0",
-        "@vuepress/plugin-theme-data": "2.0.0-rc.0",
-        "@vuepress/shared": "2.0.0-rc.0",
-        "@vuepress/utils": "2.0.0-rc.0",
-        "@vueuse/core": "^10.6.1",
-        "sass": "^1.69.5",
-        "vue": "^3.3.8",
+        "vue": "^3.4.15",
         "vue-router": "^4.2.5"
       },
       "peerDependencies": {
-        "sass-loader": "^13.3.2"
+        "vuepress": "2.0.0-rc.2"
+      }
+    },
+    "node_modules/@vuepress/plugin-back-to-top": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-back-to-top/-/plugin-back-to-top-2.0.0-rc.1.tgz",
+      "integrity": "sha512-6uxWbNTLUBBdGDPv+n35ag4IyNsS5kLyVeOajYboG/1tS5kYuoKc9ZKDw20dHIXW6Z7zdsqLuaGg4F0T5HRenw==",
+      "dev": true,
+      "dependencies": {
+        "ts-debounce": "^4.0.0",
+        "vue": "^3.4.15"
+      },
+      "peerDependencies": {
+        "vuepress": "2.0.0-rc.2"
+      }
+    },
+    "node_modules/@vuepress/plugin-container": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-container/-/plugin-container-2.0.0-rc.1.tgz",
+      "integrity": "sha512-60dPvy5u/qp0siE3MWAP/HU+FXKcTzml3/pQRuP1aBEiscUKW1DTD+2KpVT/wC3afHH2yAqDFaxKrVV5dC4+Zw==",
+      "dev": true,
+      "dependencies": {
+        "@types/markdown-it": "^13.0.7",
+        "markdown-it": "^14.0.0",
+        "markdown-it-container": "^4.0.0"
+      },
+      "peerDependencies": {
+        "vuepress": "2.0.0-rc.2"
+      }
+    },
+    "node_modules/@vuepress/plugin-external-link-icon": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-external-link-icon/-/plugin-external-link-icon-2.0.0-rc.1.tgz",
+      "integrity": "sha512-6zGt5qAnPn+sFJdOpSYAQfq/OV8vRfynTfwtSZVU0QiLVk1GDTTssGjZ32GKxmPPilXF0tiSMTcITfFllnNUmA==",
+      "dev": true,
+      "dependencies": {
+        "vue": "^3.4.15"
+      },
+      "peerDependencies": {
+        "vuepress": "2.0.0-rc.2"
+      }
+    },
+    "node_modules/@vuepress/plugin-git": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-git/-/plugin-git-2.0.0-rc.1.tgz",
+      "integrity": "sha512-k3bS/wxJ5xpxg2Hzy7FEaskpYTKohazP+Dg6z7GUI+rnxfh6H+pMeIWXg/eTTqTC6Zbq1+pNfzuYvZ64GMHpQw==",
+      "dev": true,
+      "dependencies": {
+        "execa": "^8.0.1"
+      },
+      "peerDependencies": {
+        "vuepress": "2.0.0-rc.2"
+      }
+    },
+    "node_modules/@vuepress/plugin-medium-zoom": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-medium-zoom/-/plugin-medium-zoom-2.0.0-rc.1.tgz",
+      "integrity": "sha512-5d19cu5z0adXf/HDqFHYcM2dBMlBgK90CAr7YnKgj/nmv2dl6bQ2AtHENUNxOx35c4F3TGgvit9fl+MIaQmrVg==",
+      "dev": true,
+      "dependencies": {
+        "medium-zoom": "^1.1.0",
+        "vue": "^3.4.15"
+      },
+      "peerDependencies": {
+        "vuepress": "2.0.0-rc.2"
+      }
+    },
+    "node_modules/@vuepress/plugin-nprogress": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-nprogress/-/plugin-nprogress-2.0.0-rc.1.tgz",
+      "integrity": "sha512-omCUxzWrOrm0c45+0MENY65mUWh+VmUAhckEqQir3waE9Ql7wD4drZ/fdUyfgHarBjSzdSCB6QguQMLwt9OOQw==",
+      "dev": true,
+      "dependencies": {
+        "vue": "^3.4.15",
+        "vue-router": "^4.2.5"
+      },
+      "peerDependencies": {
+        "vuepress": "2.0.0-rc.2"
+      }
+    },
+    "node_modules/@vuepress/plugin-palette": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-palette/-/plugin-palette-2.0.0-rc.1.tgz",
+      "integrity": "sha512-oe/lTE/qcb2lTF3KqQbX/k8oyitM9fo7sKiodPpjxQtjh4cee3BeQhDSNS5NjajDDcj950WBS6gRD6ha5JuuRw==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": "^3.5.3"
+      },
+      "peerDependencies": {
+        "vuepress": "2.0.0-rc.2"
+      }
+    },
+    "node_modules/@vuepress/plugin-prismjs": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-prismjs/-/plugin-prismjs-2.0.0-rc.1.tgz",
+      "integrity": "sha512-rk4aI8c31H8qt2UXFLa5iap6snWf2OLb4ixjLtdEIMcsDlrE9Gx6Rc9a+/oSp3HI0woNpKlxu1X6PEDB8Vv0zg==",
+      "dev": true,
+      "dependencies": {
+        "prismjs": "^1.29.0"
+      },
+      "peerDependencies": {
+        "vuepress": "2.0.0-rc.2"
+      }
+    },
+    "node_modules/@vuepress/plugin-search": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-search/-/plugin-search-2.0.0-rc.1.tgz",
+      "integrity": "sha512-zON1YS6udFcDFox/ypbFWNGdpQEDvku/wjlVnwlwBiuhyjWZsjMUIBypjjJx5Q3barWhpPCFJA43YBYCpieTcA==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": "^3.5.3",
+        "vue": "^3.4.15",
+        "vue-router": "^4.2.5"
+      },
+      "peerDependencies": {
+        "vuepress": "2.0.0-rc.2"
+      }
+    },
+    "node_modules/@vuepress/plugin-theme-data": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-theme-data/-/plugin-theme-data-2.0.0-rc.1.tgz",
+      "integrity": "sha512-PaVGCY4wsaFFUgue4b7yK5lGoQk4PTx6WwukbTR4cbRqY9kxX2Abpgp5EDoRBrcRbNzt85DV9voMQJr3Vx/BIg==",
+      "dev": true,
+      "dependencies": {
+        "@vue/devtools-api": "^6.5.1",
+        "vue": "^3.4.15"
+      },
+      "peerDependencies": {
+        "vuepress": "2.0.0-rc.2"
+      }
+    },
+    "node_modules/@vuepress/shared": {
+      "version": "2.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@vuepress/shared/-/shared-2.0.0-rc.2.tgz",
+      "integrity": "sha512-2kmm0rw+WalRWrSC5pW0TXRz8Wyuh57XmOZEUOhPOflw4o8Dno+PcaWbdOZ/TLkTgTt3X1n7r1/c1ALtaLta8g==",
+      "dev": true,
+      "dependencies": {
+        "@mdit-vue/types": "^2.0.0"
+      }
+    },
+    "node_modules/@vuepress/theme-default": {
+      "version": "2.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@vuepress/theme-default/-/theme-default-2.0.0-rc.2.tgz",
+      "integrity": "sha512-v8uqcC7M2Z6tImXYQakT8+4Fg6ea2Q5KucXylVKKBE8eP7a6L+3DkD+c4kUpFvKUhZCHoPR1d84mK3NQhSMg2Q==",
+      "dev": true,
+      "dependencies": {
+        "@vuepress/plugin-active-header-links": "2.0.0-rc.1",
+        "@vuepress/plugin-back-to-top": "2.0.0-rc.1",
+        "@vuepress/plugin-container": "2.0.0-rc.1",
+        "@vuepress/plugin-external-link-icon": "2.0.0-rc.1",
+        "@vuepress/plugin-git": "2.0.0-rc.1",
+        "@vuepress/plugin-medium-zoom": "2.0.0-rc.1",
+        "@vuepress/plugin-nprogress": "2.0.0-rc.1",
+        "@vuepress/plugin-palette": "2.0.0-rc.1",
+        "@vuepress/plugin-prismjs": "2.0.0-rc.1",
+        "@vuepress/plugin-theme-data": "2.0.0-rc.1",
+        "@vueuse/core": "^10.7.2",
+        "sass": "^1.70.0",
+        "vue": "^3.4.15",
+        "vue-router": "^4.2.5"
+      },
+      "peerDependencies": {
+        "sass-loader": "^14.0.0",
+        "vuepress": "2.0.0-rc.2"
       },
       "peerDependenciesMeta": {
         "sass-loader": {
@@ -1166,33 +1185,33 @@
       }
     },
     "node_modules/@vuepress/utils": {
-      "version": "2.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@vuepress/utils/-/utils-2.0.0-rc.0.tgz",
-      "integrity": "sha512-Q1ay/woClDHcW0Qe91KsnHoupdNN0tp/vhjvVLuAYxlv/1Obii7hz9WFcajyyGEhmsYxdvG2sGmcxFA02tuKkw==",
+      "version": "2.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@vuepress/utils/-/utils-2.0.0-rc.2.tgz",
+      "integrity": "sha512-g93yFJKtztpdXm4XyOIQ9QcUrKuvuWizvH3qWDQ5/WKlxa6VqE7nVNPlkudgGUIc7Bl4AGrlHcmgvkwaNoMcfA==",
       "dev": true,
       "dependencies": {
         "@types/debug": "^4.1.12",
         "@types/fs-extra": "^11.0.4",
         "@types/hash-sum": "^1.0.2",
-        "@vuepress/shared": "2.0.0-rc.0",
+        "@vuepress/shared": "2.0.0-rc.2",
         "debug": "^4.3.4",
-        "fs-extra": "^11.1.1",
+        "fs-extra": "^11.2.0",
         "globby": "^14.0.0",
         "hash-sum": "^2.0.0",
-        "ora": "^7.0.1",
+        "ora": "^8.0.1",
         "picocolors": "^1.0.0",
         "upath": "^2.0.1"
       }
     },
     "node_modules/@vueuse/core": {
-      "version": "10.6.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.6.1.tgz",
-      "integrity": "sha512-Pc26IJbqgC9VG1u6VY/xrXXfxD33hnvxBnKrLlA2LJlyHII+BSrRoTPJgGYq7qZOu61itITFUnm6QbacwZ4H8Q==",
+      "version": "10.7.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.7.2.tgz",
+      "integrity": "sha512-AOyAL2rK0By62Hm+iqQn6Rbu8bfmbgaIMXcE3TSr7BdQ42wnSFlwIdPjInO62onYsEMK/yDMU8C6oGfDAtZ2qQ==",
       "dev": true,
       "dependencies": {
         "@types/web-bluetooth": "^0.0.20",
-        "@vueuse/metadata": "10.6.1",
-        "@vueuse/shared": "10.6.1",
+        "@vueuse/metadata": "10.7.2",
+        "@vueuse/shared": "10.7.2",
         "vue-demi": ">=0.14.6"
       },
       "funding": {
@@ -1226,18 +1245,18 @@
       }
     },
     "node_modules/@vueuse/metadata": {
-      "version": "10.6.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.6.1.tgz",
-      "integrity": "sha512-qhdwPI65Bgcj23e5lpGfQsxcy0bMjCAsUGoXkJ7DsoeDUdasbZ2DBa4dinFCOER3lF4gwUv+UD2AlA11zdzMFw==",
+      "version": "10.7.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.7.2.tgz",
+      "integrity": "sha512-kCWPb4J2KGrwLtn1eJwaJD742u1k5h6v/St5wFe8Quih90+k2a0JP8BS4Zp34XUuJqS2AxFYMb1wjUL8HfhWsQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@vueuse/shared": {
-      "version": "10.6.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.6.1.tgz",
-      "integrity": "sha512-TECVDTIedFlL0NUfHWncf3zF9Gc4VfdxfQc8JFwoVZQmxpONhLxFrlm0eHQeidHj4rdTPL3KXJa0TZCk1wnc5Q==",
+      "version": "10.7.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.7.2.tgz",
+      "integrity": "sha512-qFbXoxS44pi2FkgFjPvF4h7c9oMDutpyBdcJdMYIMg9XyXli2meFMuaKn+UMgsClo//Th6+beeCgqweT/79BVA==",
       "dev": true,
       "dependencies": {
         "vue-demi": ">=0.14.6"
@@ -1307,9 +1326,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.16",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.16.tgz",
-      "integrity": "sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==",
+      "version": "10.4.17",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.17.tgz",
+      "integrity": "sha512-/cpVNRLSfhOtcGflT13P2794gVSgmPgTR+erw5ifnMLZb0UnSlkK4tquLmkd3BhA+nLo5tX8Cu0upUsGKvKbmg==",
       "dev": true,
       "funding": [
         {
@@ -1326,9 +1345,9 @@
         }
       ],
       "dependencies": {
-        "browserslist": "^4.21.10",
-        "caniuse-lite": "^1.0.30001538",
-        "fraction.js": "^4.3.6",
+        "browserslist": "^4.22.2",
+        "caniuse-lite": "^1.0.30001578",
+        "fraction.js": "^4.3.7",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
         "postcss-value-parser": "^4.2.0"
@@ -1343,26 +1362,6 @@
         "postcss": "^8.1.0"
       }
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1370,17 +1369,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/bl": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
-      "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
-      "dev": true,
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/braces": {
@@ -1396,9 +1384,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
-      "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.3.tgz",
+      "integrity": "sha512-UAp55yfwNv0klWNapjs/ktHoguxuQNGnOzxYmfnXIS+8AsRDZkSDxg7R1AX3GKzn078SBI5dzwzj/Yx0Or0e3A==",
       "dev": true,
       "funding": [
         {
@@ -1415,9 +1403,9 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001541",
-        "electron-to-chromium": "^1.4.535",
-        "node-releases": "^2.0.13",
+        "caniuse-lite": "^1.0.30001580",
+        "electron-to-chromium": "^1.4.648",
+        "node-releases": "^2.0.14",
         "update-browserslist-db": "^1.0.13"
       },
       "bin": {
@@ -1425,30 +1413,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/cac": {
@@ -1461,9 +1425,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001565",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001565.tgz",
-      "integrity": "sha512-xrE//a3O7TP0vaJ8ikzkD2c2NgcVUvsEe2IvFTntV4Yd1Z9FVzh+gW+enX96L0psrbaFMcVcH2l90xNuGDWc8w==",
+      "version": "1.0.30001581",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001581.tgz",
+      "integrity": "sha512-whlTkwhqV2tUmP3oYhtNfaWGYHDdS3JYFQBKXxcUR9qqPWsRhFHhoISO2Xnl/g0xyKzht9mI1LZpiNWfMzHixQ==",
       "dev": true,
       "funding": [
         {
@@ -1570,9 +1534,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true
     },
     "node_modules/debug": {
@@ -1592,16 +1556,10 @@
         }
       }
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true
-    },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.597",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.597.tgz",
-      "integrity": "sha512-0XOQNqHhg2YgRVRUrS4M4vWjFCFIP2ETXcXe/0KIQBjXE9Cpy+tgzzYfuq6HGai3hWq0YywtG+5XK8fyG08EjA==",
+      "version": "1.4.650",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.650.tgz",
+      "integrity": "sha512-sYSQhJCJa4aGA1wYol5cMQgekDBlbVfTRavlGZVr3WZpDdOPcp6a6xUnFfrt8TqZhsBYYbDxJZCjGfHuGupCRQ==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -1611,9 +1569,9 @@
       "dev": true
     },
     "node_modules/entities": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
       "engines": {
         "node": ">=0.12"
@@ -1635,9 +1593,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.8.tgz",
-      "integrity": "sha512-l7iffQpT2OrZfH2rXIp7/FkmaeZM0vxbxN9KfiCwGYuZqzMg/JdvX26R31Zxn/Pxvsrg3Y9N6XTcnknqDyyv4w==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
+      "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -1647,28 +1605,29 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.19.8",
-        "@esbuild/android-arm64": "0.19.8",
-        "@esbuild/android-x64": "0.19.8",
-        "@esbuild/darwin-arm64": "0.19.8",
-        "@esbuild/darwin-x64": "0.19.8",
-        "@esbuild/freebsd-arm64": "0.19.8",
-        "@esbuild/freebsd-x64": "0.19.8",
-        "@esbuild/linux-arm": "0.19.8",
-        "@esbuild/linux-arm64": "0.19.8",
-        "@esbuild/linux-ia32": "0.19.8",
-        "@esbuild/linux-loong64": "0.19.8",
-        "@esbuild/linux-mips64el": "0.19.8",
-        "@esbuild/linux-ppc64": "0.19.8",
-        "@esbuild/linux-riscv64": "0.19.8",
-        "@esbuild/linux-s390x": "0.19.8",
-        "@esbuild/linux-x64": "0.19.8",
-        "@esbuild/netbsd-x64": "0.19.8",
-        "@esbuild/openbsd-x64": "0.19.8",
-        "@esbuild/sunos-x64": "0.19.8",
-        "@esbuild/win32-arm64": "0.19.8",
-        "@esbuild/win32-ia32": "0.19.8",
-        "@esbuild/win32-x64": "0.19.8"
+        "@esbuild/aix-ppc64": "0.19.12",
+        "@esbuild/android-arm": "0.19.12",
+        "@esbuild/android-arm64": "0.19.12",
+        "@esbuild/android-x64": "0.19.12",
+        "@esbuild/darwin-arm64": "0.19.12",
+        "@esbuild/darwin-x64": "0.19.12",
+        "@esbuild/freebsd-arm64": "0.19.12",
+        "@esbuild/freebsd-x64": "0.19.12",
+        "@esbuild/linux-arm": "0.19.12",
+        "@esbuild/linux-arm64": "0.19.12",
+        "@esbuild/linux-ia32": "0.19.12",
+        "@esbuild/linux-loong64": "0.19.12",
+        "@esbuild/linux-mips64el": "0.19.12",
+        "@esbuild/linux-ppc64": "0.19.12",
+        "@esbuild/linux-riscv64": "0.19.12",
+        "@esbuild/linux-s390x": "0.19.12",
+        "@esbuild/linux-x64": "0.19.12",
+        "@esbuild/netbsd-x64": "0.19.12",
+        "@esbuild/openbsd-x64": "0.19.12",
+        "@esbuild/sunos-x64": "0.19.12",
+        "@esbuild/win32-arm64": "0.19.12",
+        "@esbuild/win32-ia32": "0.19.12",
+        "@esbuild/win32-x64": "0.19.12"
       }
     },
     "node_modules/escalade": {
@@ -1790,9 +1749,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.0.tgz",
+      "integrity": "sha512-zGygtijUMT7jnk3h26kUms3BkSDp4IfIKjmnqI2tvx6nuBfiF1UqOxbnLfzdv+apBy+53oaImsKtMw/xYbW+1w==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -1849,6 +1808,18 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz",
+      "integrity": "sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-stream": {
@@ -1931,26 +1902,6 @@
         "node": ">=16.17.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/ignore": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
@@ -1961,15 +1912,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
-      "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==",
-      "dev": true
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.5.tgz",
+      "integrity": "sha512-8eabxkth9gZatlwl5TBuJnCsoTADlL6ftEr7A4qgdaTsPyreilDSnUk57SO+jfKcNtxPa22U5KK6DSeAYhpBJw==",
       "dev": true
     },
     "node_modules/is-binary-path": {
@@ -2048,12 +1993,12 @@
       }
     },
     "node_modules/is-unicode-supported": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.0.0.tgz",
+      "integrity": "sha512-FRdAyx5lusK1iHG0TWpVtk9+1i+GjrzRffhDg4ovQ7mcidMQ6mj+MhKPmvh7Xwyv5gIS06ns49CA7Sqg7lC22Q==",
       "dev": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2109,23 +2054,35 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
-      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
       "dev": true,
       "dependencies": {
-        "uc.micro": "^1.0.1"
+        "uc.micro": "^2.0.0"
       }
     },
     "node_modules/log-symbols": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
-      "integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
       "dev": true,
       "dependencies": {
-        "chalk": "^5.0.0",
-        "is-unicode-supported": "^1.1.0"
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -2146,19 +2103,20 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.2.tgz",
-      "integrity": "sha512-FtwnEuuK+2yVU7goGn/MJ0WBZMM9ZPgU9spqlFs7/A/pDIUNSOQZhUgOqYCficIuR2QaFnrt8LHqBWsbTAoI5w==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.0.0.tgz",
+      "integrity": "sha512-seFjF0FIcPt4P9U39Bq1JYblX0KZCjDLFFQPHpL5AzHpqPEKtosxmdq/LTVZnjfH7tjt9BxStm+wXcDBNuYmzw==",
       "dev": true,
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "~3.0.1",
-        "linkify-it": "^4.0.1",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.0.0"
       },
       "bin": {
-        "markdown-it": "bin/markdown-it.js"
+        "markdown-it": "bin/markdown-it.mjs"
       }
     },
     "node_modules/markdown-it-anchor": {
@@ -2172,15 +2130,15 @@
       }
     },
     "node_modules/markdown-it-container": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-container/-/markdown-it-container-3.0.0.tgz",
-      "integrity": "sha512-y6oKTq4BB9OQuY/KLfk/O3ysFhB3IMYoIWhGJEidXt1NQFocFK2sA2t0NYZAMyMShAGL6x5OPIbrmXPIqaN9rw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-container/-/markdown-it-container-4.0.0.tgz",
+      "integrity": "sha512-HaNccxUH0l7BNGYbFbjmGpf5aLHAMTinqRZQAEQbMr2cdD3z91Q6kIo1oUn1CQndkT03jat6ckrdRYuwwqLlQw==",
       "dev": true
     },
     "node_modules/markdown-it-emoji": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-2.0.2.tgz",
-      "integrity": "sha512-zLftSaNrKuYl0kR5zm4gxXjHaOI3FAOEaloKmRA5hijmJZvSjmxcokOLlzycb/HXlUFWzXqpIEoyEMCE4i9MvQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-3.0.0.tgz",
+      "integrity": "sha512-+rUD93bXHubA4arpEZO3q80so0qgoFJEKRkRbjKX8RTdca89v2kfyF+xR3i2sQTwql9tpPZPOQN5B+PunspXRg==",
       "dev": true
     },
     "node_modules/markdown-it/node_modules/argparse": {
@@ -2190,9 +2148,9 @@
       "dev": true
     },
     "node_modules/mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true
     },
     "node_modules/medium-zoom": {
@@ -2263,9 +2221,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
       "dev": true
     },
     "node_modules/normalize-path": {
@@ -2287,9 +2245,9 @@
       }
     },
     "node_modules/npm-run-path": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
-      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.2.0.tgz",
+      "integrity": "sha512-W4/tgAXFqFA0iL7fk0+uQ3g7wkL8xJmx3XdK0VGb4cHW//eZTtKGvFBBoRKVTpY7n6ze4NL9ly7rgXcHufqXKg==",
       "dev": true,
       "dependencies": {
         "path-key": "^4.0.0"
@@ -2329,23 +2287,23 @@
       }
     },
     "node_modules/ora": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-7.0.1.tgz",
-      "integrity": "sha512-0TUxTiFJWv+JnjWm4o9yvuskpEJLXTcng8MJuKd+SzAzp2o+OP3HWqNhB4OdJRt1Vsd9/mR0oyaEYlOnL7XIRw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.0.1.tgz",
+      "integrity": "sha512-ANIvzobt1rls2BDny5fWZ3ZVKyD6nscLvfFRpQgfWsythlcsVUC9kL0zq6j2Z5z9wwp1kd7wpsD/T9qNPVLCaQ==",
       "dev": true,
       "dependencies": {
         "chalk": "^5.3.0",
         "cli-cursor": "^4.0.0",
-        "cli-spinners": "^2.9.0",
+        "cli-spinners": "^2.9.2",
         "is-interactive": "^2.0.0",
-        "is-unicode-supported": "^1.3.0",
-        "log-symbols": "^5.1.0",
-        "stdin-discarder": "^0.1.0",
-        "string-width": "^6.1.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.1",
+        "string-width": "^7.0.0",
         "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2391,9 +2349,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.4.33",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
+      "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
       "dev": true,
       "funding": [
         {
@@ -2410,7 +2368,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -2419,9 +2377,9 @@
       }
     },
     "node_modules/postcss-load-config": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
-      "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-5.0.2.tgz",
+      "integrity": "sha512-Q8QR3FYbqOKa0bnC1UQ2bFq9/ulHX5Bi34muzitMr8aDtUelO5xKeJEYC/5smE0jNE9zdB/NBnOwXKexELbRlw==",
       "dev": true,
       "funding": [
         {
@@ -2438,17 +2396,17 @@
         "yaml": "^2.3.4"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       },
       "peerDependencies": {
-        "postcss": ">=8.0.9",
-        "ts-node": ">=9.0.0"
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9"
       },
       "peerDependenciesMeta": {
-        "postcss": {
+        "jiti": {
           "optional": true
         },
-        "ts-node": {
+        "postcss": {
           "optional": true
         }
       }
@@ -2463,6 +2421,15 @@
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
       "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -2487,20 +2454,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -2541,10 +2494,13 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.6.1.tgz",
-      "integrity": "sha512-jZHaZotEHQaHLgKr8JnQiDT1rmatjgKlMekyksz+yk9jt/8z9quNjnKNRoaM0wd9DC2QKXjmWWuDYtM3jfF8pQ==",
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.6.tgz",
+      "integrity": "sha512-05lzkCS2uASX0CiLFybYfVkwNbKZG5NFQ6Go0VWyogFTXXbR039UVsegViTntkk4OglHBdF54ccApXRRuXRbsg==",
       "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.5"
+      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -2553,18 +2509,19 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.6.1",
-        "@rollup/rollup-android-arm64": "4.6.1",
-        "@rollup/rollup-darwin-arm64": "4.6.1",
-        "@rollup/rollup-darwin-x64": "4.6.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.6.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.6.1",
-        "@rollup/rollup-linux-arm64-musl": "4.6.1",
-        "@rollup/rollup-linux-x64-gnu": "4.6.1",
-        "@rollup/rollup-linux-x64-musl": "4.6.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.6.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.6.1",
-        "@rollup/rollup-win32-x64-msvc": "4.6.1",
+        "@rollup/rollup-android-arm-eabi": "4.9.6",
+        "@rollup/rollup-android-arm64": "4.9.6",
+        "@rollup/rollup-darwin-arm64": "4.9.6",
+        "@rollup/rollup-darwin-x64": "4.9.6",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.9.6",
+        "@rollup/rollup-linux-arm64-gnu": "4.9.6",
+        "@rollup/rollup-linux-arm64-musl": "4.9.6",
+        "@rollup/rollup-linux-riscv64-gnu": "4.9.6",
+        "@rollup/rollup-linux-x64-gnu": "4.9.6",
+        "@rollup/rollup-linux-x64-musl": "4.9.6",
+        "@rollup/rollup-win32-arm64-msvc": "4.9.6",
+        "@rollup/rollup-win32-ia32-msvc": "4.9.6",
+        "@rollup/rollup-win32-x64-msvc": "4.9.6",
         "fsevents": "~2.3.2"
       }
     },
@@ -2591,30 +2548,10 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/sass": {
-      "version": "1.69.5",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.5.tgz",
-      "integrity": "sha512-qg2+UCJibLr2LCVOt3OlPhr/dqVHWOa9XtZf2OjbLs/T4VPSJ00udtgJxH3neXZm+QqX8B+3cU7RaLqp1iVfcQ==",
+      "version": "1.70.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.70.0.tgz",
+      "integrity": "sha512-uUxNQ3zAHeAx5nRFskBnrWzDUJrrvpCPD5FNAoRvTi0WwremlheES3tg+56PaVtCs5QDRX5CBLxxKMDJMEa1WQ==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -2696,41 +2633,29 @@
       "dev": true
     },
     "node_modules/stdin-discarder": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.1.0.tgz",
-      "integrity": "sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
       "dev": true,
-      "dependencies": {
-        "bl": "^5.0.0"
-      },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "node_modules/string-width": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-6.1.0.tgz",
-      "integrity": "sha512-k01swCJAgQmuADB0YIc+7TuatfNvTBVOoaUWJjTB9R4VJzR5vNWzf5t42ESVZFPS8xTySF7CAdV4t/aaIm3UnQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.1.0.tgz",
+      "integrity": "sha512-SEIJCWiX7Kg4c129n48aDRwLbFb2LJmXXFrWBG4NGaRtMQ3myKPKbwrD1BKqQn74oCoNMBVrfDEr5M9YxCsrkw==",
       "dev": true,
       "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^10.2.1",
-        "strip-ansi": "^7.0.1"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2791,9 +2716,9 @@
       "dev": true
     },
     "node_modules/uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.0.0.tgz",
+      "integrity": "sha512-DffL94LsNOccVn4hyfRe5rdKa273swqeA5DJpMOeFmEn1wCDc7nAbbB0gXlgBCL7TNzeTv6G7XVWzan7iJtfig==",
       "dev": true
     },
     "node_modules/undici-types": {
@@ -2863,20 +2788,14 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
-    },
     "node_modules/vite": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.4.tgz",
-      "integrity": "sha512-RzAr8LSvM8lmhB4tQ5OPcBhpjOZRZjuxv9zO5UcxeoY2bd3kP3Ticd40Qma9/BqZ8JS96Ll/jeBX9u+LJZrhVg==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
+      "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",
-        "postcss": "^8.4.31",
+        "postcss": "^8.4.32",
         "rollup": "^4.2.0"
       },
       "bin": {
@@ -2925,16 +2844,16 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.9.tgz",
-      "integrity": "sha512-sy5sLCTR8m6tvUk1/ijri3Yqzgpdsmxgj6n6yl7GXXCXqVbmW2RCXe9atE4cEI6Iv7L89v5f35fZRRr5dChP9w==",
+      "version": "3.4.15",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.15.tgz",
+      "integrity": "sha512-jC0GH4KkWLWJOEQjOpkqU1bQsBwf4R1rsFtw5GQJbjHVKWDzO6P0nWWBTmjp1xSemAioDFj1jdaK1qa3DnMQoQ==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.3.9",
-        "@vue/compiler-sfc": "3.3.9",
-        "@vue/runtime-dom": "3.3.9",
-        "@vue/server-renderer": "3.3.9",
-        "@vue/shared": "3.3.9"
+        "@vue/compiler-dom": "3.4.15",
+        "@vue/compiler-sfc": "3.4.15",
+        "@vue/runtime-dom": "3.4.15",
+        "@vue/server-renderer": "3.4.15",
+        "@vue/shared": "3.4.15"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -2961,42 +2880,39 @@
       }
     },
     "node_modules/vuepress": {
-      "version": "2.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/vuepress/-/vuepress-2.0.0-rc.0.tgz",
-      "integrity": "sha512-sydt/B7+pIw926G5PntYmptLkC5o2buXKh+WR1+P2KnsvkXU+UGnQrJJ0FBvu/4RNuY99tkUZd59nyPhEmRrCg==",
+      "version": "2.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/vuepress/-/vuepress-2.0.0-rc.2.tgz",
+      "integrity": "sha512-OEHfXx4Q3IzkXqcY9bKZqHXYAnSR82AGrmWYX5R1I3+ntzjaAbUhUKbG/jjMzLg40XqAHS++pM/zzMBNrcY3rg==",
       "dev": true,
       "dependencies": {
-        "vuepress-vite": "2.0.0-rc.0"
-      },
-      "bin": {
-        "vuepress": "bin/vuepress.js"
-      },
-      "engines": {
-        "node": ">=18.16.0"
-      }
-    },
-    "node_modules/vuepress-vite": {
-      "version": "2.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/vuepress-vite/-/vuepress-vite-2.0.0-rc.0.tgz",
-      "integrity": "sha512-+2XBejeiskPyr2raBeA2o4uDFDsjtadpUVmtio3qqFtQpOhidz/ORuiTLr2UfLtFn1ASIHP6Vy2YjQ0e/TeUVw==",
-      "dev": true,
-      "dependencies": {
-        "@vuepress/bundler-vite": "2.0.0-rc.0",
-        "@vuepress/cli": "2.0.0-rc.0",
-        "@vuepress/core": "2.0.0-rc.0",
-        "@vuepress/theme-default": "2.0.0-rc.0",
-        "vue": "^3.3.8"
+        "@vuepress/cli": "2.0.0-rc.2",
+        "@vuepress/client": "2.0.0-rc.2",
+        "@vuepress/core": "2.0.0-rc.2",
+        "@vuepress/markdown": "2.0.0-rc.2",
+        "@vuepress/shared": "2.0.0-rc.2",
+        "@vuepress/utils": "2.0.0-rc.2",
+        "vue": "^3.4.15"
       },
       "bin": {
         "vuepress": "bin/vuepress.js",
-        "vuepress-vite": "bin/vuepress.js"
+        "vuepress-vite": "bin/vuepress-vite.js",
+        "vuepress-webpack": "bin/vuepress-webpack.js"
       },
       "engines": {
         "node": ">=18.16.0"
       },
       "peerDependencies": {
-        "@vuepress/client": "2.0.0-rc.0",
-        "vue": "^3.3.4"
+        "@vuepress/bundler-vite": "2.0.0-rc.2",
+        "@vuepress/bundler-webpack": "2.0.0-rc.2",
+        "vue": "^3.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@vuepress/bundler-vite": {
+          "optional": true
+        },
+        "@vuepress/bundler-webpack": {
+          "optional": true
+        }
       }
     },
     "node_modules/which": {

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-documentation",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Developer and End-user documentation",
   "main": "index.js",
   "scripts": {
@@ -12,7 +12,9 @@
   "author": "DESCW",
   "license": "ISC",
   "devDependencies": {
-    "@vuepress/plugin-search": "^2.0.0-rc",
-    "vuepress": "^2.0.0-rc"
+    "@vuepress/plugin-search": "^2.0.0-rc.0",
+    "@vuepress/theme-default": "^2.0.0-rc.0",
+    "@vuepress/bundler-vite": "^2.0.0-rc.0",
+    "vuepress": "^2.0.0-rc.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bcgov-wordpress-block-theme",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Bcgov WordPress Block Theme",
   "author": "govwordpress@gov.bc.ca",
   "license": "Apache-2.0",

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ Description: WordPress Block theme is a theme that leverages the full-site editi
 Requires at least: 6.2
 Tested up to: 6.2.2
 Requires PHP: 7.4
-Version: 1.4.0
+Version: 1.4.1
 License: Apache License Version 2.0
 License URI: LICENSE
 Text Domain: bcgov-blocks-theme


### PR DESCRIPTION
- Updated Vuepress to 2.0.0-rc.0 to address XSS security concern
- Had to install @vuepress/theme-default 2.0.0-rc.0 and @vuepress/bundler-vite 2.0.0-rc.0 as dev dependencies to get documentation to build
- Also added bundler source as Vite Bundler in config.js
- Documentation is now building successfully again
- Tested documentation front-end from local Block Theme environment 
    - working as expected