### PR TITLE
DESCW-2479 update package-lock deps for ws.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 1.12.0 July 18, 2024
+-([DESCW-2479](https://citz-gdx.atlassian.net/browse/DESCW-2479)) fixing dependabot error.
+
 ## 1.11.00 July 4, 2024
 - ([DESCW-2480](https://citz-gdx.atlassian.net/browse/DESCW-2480)) adding excerpt for pages.
 

--- a/checklist.md
+++ b/checklist.md
@@ -1,10 +1,10 @@
-Created at 2024-07-04 9:02 am
+Created at 2024-07-18 3:56 pm
 
 * [yes] Updated version in composer.json
 * [yes] Updated version in style.css or plugin file
 * [yes] Updated CHANGELOG.md to include jira ticket
 * [no] Updated README.md for new functionality
-* [no] Built assets for production (npm run build:production)
+* [yes] Built assets for production (npm run build:production)
 * [N/A] Updated the documentation (N/A, Updated, or a ticket ID)
 * [✓] Verified coding standards (phpcs)
 * [✓] Run PHP tests

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "bcgov-theme/bcgov-wordpress-block-theme",
     "description": "Block Theme for BC Gov",
-    "version": "1.11.0",
+    "version": "1.12.0",
     "type": "wordpress-theme",
     "license": "Apache-2.0",
     "repositories": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -11681,7 +11681,7 @@
         "whatwg-encoding": "^2.0.0",
         "whatwg-mimetype": "^3.0.0",
         "whatwg-url": "^11.0.0",
-        "ws": "^8.11.0",
+        "ws": "^8.17.1",
         "xml-name-validator": "^4.0.0"
       },
       "engines": {
@@ -11926,7 +11926,7 @@
         "semver": "^5.3.0",
         "speedline-core": "^1.4.3",
         "third-party-web": "^0.23.3",
-        "ws": "^7.0.0",
+        "ws": "^7.5.10",
         "yargs": "^17.3.1",
         "yargs-parser": "^21.0.0"
       },
@@ -12036,7 +12036,7 @@
         "cross-fetch": "4.0.0",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1147663",
-        "ws": "8.13.0"
+        "ws": "8.17.1"
       },
       "engines": {
         "node": ">=16.3.0"
@@ -12069,9 +12069,9 @@
       "dev": true
     },
     "node_modules/lighthouse/node_modules/puppeteer-core/node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -14667,7 +14667,7 @@
         "rimraf": "3.0.2",
         "tar-fs": "2.1.1",
         "unbzip2-stream": "1.4.3",
-        "ws": "8.5.0"
+        "ws": "8.17.1"
       },
       "engines": {
         "node": ">=10.18.1"
@@ -14710,27 +14710,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/ws": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/pure-rand": {
@@ -17776,7 +17755,7 @@
         "opener": "^1.5.2",
         "picocolors": "^1.0.0",
         "sirv": "^2.0.3",
-        "ws": "^7.3.1"
+        "ws": "7.5.10"
       },
       "bin": {
         "webpack-bundle-analyzer": "lib/bin/analyzer.js"
@@ -17977,7 +17956,7 @@
         "sockjs": "^0.3.24",
         "spdy": "^4.0.2",
         "webpack-dev-middleware": "^5.3.4",
-        "ws": "^8.13.0"
+        "ws": "^8.17.1"
       },
       "bin": {
         "webpack-dev-server": "bin/webpack-dev-server.js"

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ Description: WordPress Block theme is a theme that leverages the full-site editi
 Requires at least: 6.2
 Tested up to: 6.2.2
 Requires PHP: 7.4
-Version: 1.11.0
+Version: 1.12.0
 License: Apache License Version 2.0
 License URI: LICENSE
 Text Domain: bcgov-blocks-theme


### PR DESCRIPTION
I made edits to the version numbers for the `ws` dependencies in package-lock.json.

This works, as long as nobody runs `npm update` on the repo, for now.

summary:
- this eliminates the audit issues, but is not ideal because it is temporary.
- the maintainers of @wordpress/scripts have a 10-version downgrade patch, but that is not going to work for us.
- I suggest going with this for now, and waiting for a patch to @wordpress/scripts@28.3.0.