### PR TITLE
Fix code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/src/scripts/public/sites/cleanbc/patterns/actions-toggle-query.js
+++ b/src/scripts/public/sites/cleanbc/patterns/actions-toggle-query.js
@@ -2,6 +2,24 @@ import { qs, qsa, addSafeEventListener } from '../../../utils';
 import { triggerClick } from '../../../../admin/utils/common';
 
 /**
+ * Escape HTML special characters in a string.
+ * @param {string} str - The string to escape.
+ * @return {string} - The escaped string.
+ */
+function escapeHtml(str) {
+    return str.replace(/[&<>"']/g, function (match) {
+        const escapeMap = {
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#39;'
+        };
+        return escapeMap[match];
+    });
+}
+
+/**
  * CleanBC Actions Toggle manipulation.
  * [@return](https://github.com/return) {void}
  */
@@ -193,7 +211,7 @@ const bcgovBlockThemeCleanbcActionsToggle = () => {
                             null === headingCounterContainer &&
                             headingCount
                         ) {
-                            headingCounter.innerHTML = `${ headingCounter.innerText } <span class="count">${ headingCount } </span>`;
+                            headingCounter.innerHTML = `${ escapeHtml(headingCounter.innerText) } <span class="count">${ headingCount } </span>`;
                         }
                     }
                 }


### PR DESCRIPTION
Fixes [https://github.com/bcgov/bcgov-wordpress-block-theme/security/code-scanning/2](https://github.com/bcgov/bcgov-wordpress-block-theme/security/code-scanning/2)

To fix the problem, we need to ensure that any text content used in constructing HTML is properly escaped to prevent XSS attacks. This can be achieved by using a function to escape HTML special characters before assigning the content to `innerHTML`.

- Create a function to escape HTML special characters.
- Use this function to escape `headingCounter.innerText` before including it in the HTML string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
